### PR TITLE
Fixed line continuation issues for dotnet publish command in YAML file

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -81,12 +81,7 @@ jobs:
         run: dotnet restore MermaidPad.csproj
 
       - name: Publish
-        run: |
-          dotnet publish MermaidPad.csproj -c Release -r ${{ matrix.rid }} -o ./publish \
-            -p:Version=${{ needs.get-version.outputs.version }} \
-            -p:AssemblyVersion=${{ needs.get-version.outputs.version }} \
-            -p:FileVersion=${{ needs.get-version.outputs.version }}
-
+        run: dotnet publish MermaidPad.csproj -c Release -r ${{ matrix.rid }} -o ./publish -p:Version=${{ needs.get-version.outputs.version }} -p:AssemblyVersion=${{ needs.get-version.outputs.version }} -p:FileVersion=${{ needs.get-version.outputs.version }}
       - name: Prepare artifact
         shell: bash
         run: |


### PR DESCRIPTION
Fixed line continuation issues for dotnet publish command in YAML file

Removed unnecessary line breaks in the dotnet publish command within `build-and-release.yml`. This change consolidates parameters into a single line, enhancing readability and maintainability.