### PR TITLE
Remove release-on-merge workflow from project file

### DIFF
--- a/MermaidPad.csproj
+++ b/MermaidPad.csproj
@@ -98,7 +98,6 @@
 
 	<ItemGroup>
 	  <None Include=".github\workflows\build-and-release.yml" />
-	  <None Include=".github\workflows\release-on-merge.yml" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Remove release-on-merge workflow from project file

The workflow for releasing on merge has been removed from the project file, streamlining the CI/CD process by eliminating unnecessary configurations.