### PR TITLE
Extend app settings to save editor state

### DIFF
--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -2,7 +2,7 @@ namespace MermaidPad.Models;
 
 public class AppSettings
 {
-    public string? LastDiagram { get; set; }
+    public string? LastDiagramText { get; set; }
     public string BundledMermaidVersion { get; set; } = "11.9.0";
     public string? LatestCheckedMermaidVersion { get; set; }
     public bool AutoUpdateMermaid { get; set; } = true;

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -7,4 +7,7 @@ public class AppSettings
     public string? LatestCheckedMermaidVersion { get; set; }
     public bool AutoUpdateMermaid { get; set; } = true;
     public bool LivePreviewEnabled { get; set; } = true;
+    public int EditorSelectionStart { get; set; }
+    public int EditorSelectionLength { get; set; }
+    public int EditorCaretOffset { get; set; }
 }

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -31,6 +31,15 @@ public partial class MainViewModel : ViewModelBase
     [ObservableProperty]
     public partial bool LivePreviewEnabled { get; set; } = true;
 
+    [ObservableProperty]
+    public partial int EditorSelectionStart { get; set; }
+
+    [ObservableProperty]
+    public partial int EditorSelectionLength { get; set; }
+
+    [ObservableProperty]
+    public partial int EditorCaretOffset { get; set; }
+
     public MainViewModel(IServiceProvider services)
     {
         _renderer = services.GetRequiredService<MermaidRenderer>();
@@ -43,6 +52,9 @@ public partial class MainViewModel : ViewModelBase
         BundledMermaidVersion = _settingsService.Settings.BundledMermaidVersion;
         LatestMermaidVersion = _settingsService.Settings.LatestCheckedMermaidVersion;
         LivePreviewEnabled = _settingsService.Settings.LivePreviewEnabled;
+        EditorSelectionStart = _settingsService.Settings.EditorSelectionStart;
+        EditorSelectionLength = _settingsService.Settings.EditorSelectionLength;
+        EditorCaretOffset = _settingsService.Settings.EditorCaretOffset;
     }
 
     [RelayCommand(CanExecute = nameof(CanRender))]
@@ -126,6 +138,9 @@ public partial class MainViewModel : ViewModelBase
         _settingsService.Settings.LivePreviewEnabled = LivePreviewEnabled;
         _settingsService.Settings.BundledMermaidVersion = BundledMermaidVersion;
         _settingsService.Settings.LatestCheckedMermaidVersion = LatestMermaidVersion;
+        _settingsService.Settings.EditorSelectionStart = EditorSelectionStart;
+        _settingsService.Settings.EditorSelectionLength = EditorSelectionLength;
+        _settingsService.Settings.EditorCaretOffset = EditorCaretOffset;
         _settingsService.Save();
     }
 

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -39,7 +39,7 @@ public partial class MainViewModel : ViewModelBase
         _editorDebouncer = services.GetRequiredService<IDebounceDispatcher>();
 
         // Initialize properties from settings
-        DiagramText = _settingsService.Settings.LastDiagram ?? SampleText();
+        DiagramText = _settingsService.Settings.LastDiagramText ?? SampleText();
         BundledMermaidVersion = _settingsService.Settings.BundledMermaidVersion;
         LatestMermaidVersion = _settingsService.Settings.LatestCheckedMermaidVersion;
         LivePreviewEnabled = _settingsService.Settings.LivePreviewEnabled;
@@ -122,7 +122,7 @@ public partial class MainViewModel : ViewModelBase
 
     public void Persist()
     {
-        _settingsService.Settings.LastDiagram = DiagramText;
+        _settingsService.Settings.LastDiagramText = DiagramText;
         _settingsService.Settings.LivePreviewEnabled = LivePreviewEnabled;
         _settingsService.Settings.BundledMermaidVersion = BundledMermaidVersion;
         _settingsService.Settings.LatestCheckedMermaidVersion = LatestMermaidVersion;

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -70,6 +70,9 @@ public partial class MainViewModel : ViewModelBase
     private async Task ClearAsync()
     {
         DiagramText = string.Empty;
+        EditorSelectionStart = 0;
+        EditorSelectionLength = 0;
+        EditorCaretOffset = 0;
         LastError = null;
         await _renderer.RenderAsync(string.Empty);
     }

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -58,6 +58,9 @@ public partial class MainWindow : Window
         };
 
         Editor.Text = _vm.DiagramText;
+        Editor.SelectionStart = _vm.EditorSelectionStart;
+        Editor.SelectionLength = _vm.EditorSelectionLength;
+        Editor.CaretOffset = _vm.EditorCaretOffset;
 
         Editor.TextChanged += (_, __) =>
         {
@@ -121,8 +124,11 @@ public partial class MainWindow : Window
         string assets = PlatformServiceFactory.Instance.GetAssetsDirectory();
         await _vm.CheckForMermaidUpdatesAsync();
 
-        // Ensure Editor and ViewModel are in sync
-        _vm.DiagramText = Editor.Text;
+        // Restore editor state from ViewModel (source of truth)
+        Editor.Text = _vm.DiagramText;
+        Editor.SelectionStart = _vm.EditorSelectionStart;
+        Editor.SelectionLength = _vm.EditorSelectionLength;
+        Editor.CaretOffset = _vm.EditorCaretOffset;
         await InitializeWebViewAsync(assets);
 
         // Ensure command state is updated after UI is loaded

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -16,6 +16,8 @@ public partial class MainWindow : Window
     private readonly MainViewModel _vm;
     private readonly MermaidRenderer _renderer;
 
+    private bool _suppressEditorTextChanged = false;
+
     public MainWindow()
     {
         InitializeComponent();
@@ -64,6 +66,8 @@ public partial class MainWindow : Window
 
         Editor.TextChanged += (_, __) =>
         {
+            if (_suppressEditorTextChanged) return;
+
             // Debounce to avoid excessive updates
             editorDebouncer.Debounce("editor-text", TimeSpan.FromMilliseconds(DebounceDispatcher.DefaultDebounceMilliseconds), () =>
             {
@@ -81,7 +85,9 @@ public partial class MainWindow : Window
                 // Debounce to avoid excessive updates
                 editorDebouncer.Debounce("vm-text", TimeSpan.FromMilliseconds(DebounceDispatcher.DefaultDebounceMilliseconds), () =>
                 {
+                    _suppressEditorTextChanged = true;
                     Editor.Text = _vm.DiagramText;
+                    _suppressEditorTextChanged = false;
                 });
             }
         };

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -64,7 +64,7 @@ public partial class MainWindow : Window
         Editor.SelectionLength = _vm.EditorSelectionLength;
         Editor.CaretOffset = _vm.EditorCaretOffset;
 
-        Editor.TextChanged += (_, __) =>
+        Editor.TextChanged += (_, _) =>
         {
             if (_suppressEditorTextChanged) return;
 
@@ -144,7 +144,17 @@ public partial class MainWindow : Window
 
     private void OnClosing(object? sender, CancelEventArgs e)
     {
+        // When the window is closing, save the current state
+        SynchronizeViewModelWithEditor();
         _vm.Persist();
+    }
+
+    private void SynchronizeViewModelWithEditor()
+    {
+        _vm.DiagramText = Editor.Text;
+        _vm.EditorSelectionStart = Editor.SelectionStart;
+        _vm.EditorSelectionLength = Editor.SelectionLength;
+        _vm.EditorCaretOffset = Editor.CaretOffset;
     }
 
     private async Task InitializeWebViewAsync(string assets)

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -60,9 +60,15 @@ public partial class MainWindow : Window
         };
 
         Editor.Text = _vm.DiagramText;
-        Editor.SelectionStart = _vm.EditorSelectionStart;
-        Editor.SelectionLength = _vm.EditorSelectionLength;
-        Editor.CaretOffset = _vm.EditorCaretOffset;
+
+        // Ensure selection bounds are valid
+        int textLength = _vm.DiagramText.Length;
+        int selectionStart = Math.Max(0, Math.Min(_vm.EditorSelectionStart, textLength));
+        int selectionLength = Math.Max(0, Math.Min(_vm.EditorSelectionLength, textLength - selectionStart));
+        int caretOffset = Math.Max(0, Math.Min(_vm.EditorCaretOffset, textLength));
+        Editor.SelectionLength = selectionLength;
+        Editor.SelectionStart = selectionStart;
+        Editor.CaretOffset = caretOffset;
 
         Editor.TextChanged += (_, _) =>
         {


### PR DESCRIPTION
#### PR Classification
Refactor and enhancement of editor state management in the application.

#### PR Summary
This pull request updates the `AppSettings` and `MainViewModel` classes to improve the management of editor state properties and synchronize them with the UI. Key changes include:
- `AppSettings.cs`: Renamed `LastDiagram` to `LastDiagramText` and added properties for editor selection and caret position.
- `MainViewModel.cs`: Updated to reflect the new property names and initialized editor state properties in the constructor.
- `MainWindow.axaml.cs`: Introduced `_suppressEditorTextChanged` to prevent unnecessary updates during text changes and added a method to synchronize editor state with the view model.
