### PR TITLE
Add zipping step for published output artifact

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -95,12 +95,18 @@ jobs:
             ARTIFACT_NAME="MermaidPad-${{ needs.get-version.outputs.version }}-${{ matrix.rid }}"
           fi
           echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
+
+      - name: Zip published output
+        shell: bash
+        run: |
+          cd publish
+          zip -r ../${ARTIFACT_NAME}.zip .
     
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          path: ./publish/**
+          path: ./${{ env.ARTIFACT_NAME }}.zip
           if-no-files-found: error
     
   # Create GitHub release


### PR DESCRIPTION
#### PR Classification
Enhancement of the build process for artifact management.

#### PR Summary
This pull request adds a step to zip the published output of the project and modifies the artifact upload process to use the newly created zip file. 
- `build-and-release.yml`: Added a step to zip the contents of the `publish` directory and upload the zip file as the artifact.
