### PR TITLE
Add IsPreview and remove zip step

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -10,6 +10,11 @@ on:
         description: 'Version to release (e.g., 1.0.0)'
         required: true
         type: string
+      is_preview:
+        description: 'Mark this release as a preview (pre-release)?'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   get-version:
@@ -148,6 +153,7 @@ jobs:
           artifacts: "./artifacts/**/*"
           generateReleaseNotes: true
           allowUpdates: true
+          prerelease: ${{ github.event.inputs.is_preview == 'true' }}
           body: |
             ## MermaidPad v${{ needs.get-version.outputs.version }}
             

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -101,19 +101,13 @@ jobs:
           fi
           echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
 
-      - name: Zip published output
-        shell: bash
-        run: |
-          cd publish
-          zip -r ../${ARTIFACT_NAME}.zip .
-    
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          path: ./${{ env.ARTIFACT_NAME }}.zip
+          path: ./publish
           if-no-files-found: error
-    
+
   # Create GitHub release
   release:
     name: Create Release
@@ -124,17 +118,17 @@ jobs:
       (github.event_name == 'workflow_dispatch' && github.event.inputs.version != '')
     permissions:
       contents: write
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         if: github.event_name == 'workflow_dispatch'
-      
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: ./artifacts
-      
+
       - name: Create or update tag for manual runs
         if: github.event_name == 'workflow_dispatch'
         run: |
@@ -144,7 +138,7 @@ jobs:
           git push origin v${{ needs.get-version.outputs.version }} --force-with-lease
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
@@ -156,10 +150,10 @@ jobs:
           prerelease: ${{ github.event.inputs.is_preview == 'true' }}
           body: |
             ## MermaidPad v${{ needs.get-version.outputs.version }}
-            
+
             ### Requirements
             - .NET 9 Runtime ([Download here](https://dotnet.microsoft.com/download/dotnet/9.0))
-            
+
             ### Downloads
             Choose the appropriate version for your platform:
             - **Windows x64**: `MermaidPad-${{ needs.get-version.outputs.version }}-win-x64.exe`
@@ -168,7 +162,7 @@ jobs:
             - **Linux ARM64**: `MermaidPad-${{ needs.get-version.outputs.version }}-linux-arm64`
             - **macOS Intel**: `MermaidPad-${{ needs.get-version.outputs.version }}-osx-x64`
             - **macOS Apple Silicon**: `MermaidPad-${{ needs.get-version.outputs.version }}-osx-arm64`
-            
+
             ### Installation
             1. Download the appropriate file for your platform
             2. Make executable (Linux/macOS): `chmod +x MermaidPad-*`


### PR DESCRIPTION
#### PR Classification
New feature to enhance release management by adding preview functionality.

#### PR Summary
This pull request introduces a new input parameter for marking releases as previews and updates the release process accordingly. Key changes include:
- `build-and-release.yml`: Added `is_preview` input parameter to mark releases as pre-releases.
- `build-and-release.yml`: Modified release job to check for pre-release status based on `is_preview`.
- `build-and-release.yml`: Changed artifact upload path to `./publish`.
- `build-and-release.yml`: Added steps for creating/updating tags for manual runs.
- `build-and-release.yml`: Enhanced release notes with download and installation instructions.
