### PR TITLE
Update artifact upload path and release requirements

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -155,7 +155,7 @@ jobs:
             ### Requirements
             - .NET 9 Runtime ([Download here](https://dotnet.microsoft.com/download/dotnet/9.0))
             - Windows: WebView2 Runtime ([Download here](https://developer.microsoft.com/en-us/microsoft-edge/webview2/?form=MA13LH#download))
-            - Linux: libwebkit2gtk-4.0-37+ (for WebView2 support)
+            - Linux: libwebkit2gtk-4.0-37+ (for WebKit support)
             - macOS: WebKit (included on macOS by default - [Download](https://webkit.org/downloads/))
 
             ### Downloads


### PR DESCRIPTION
Update artifact upload path and release requirements

Modified `build-and-release.yml` to simplify the artifact upload path from `./publish/${{ env.ARTIFACT_NAME }}` to `./publish`. Added requirements for WebView2 Runtime on Windows, libwebkit2gtk-4.0-37 on Linux, and noted that WebKit is included by default on macOS.