### PR TITLE
Update artifact naming and zipping in release workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -94,11 +94,9 @@ jobs:
         run: |
           if [ "${{ matrix.extension }}" = ".exe" ]; then
             mv MermaidPad.exe MermaidPad-${{ needs.get-version.outputs.version }}-${{ matrix.rid }}.exe
-            MAIN_BINARY="MermaidPad-${{ needs.get-version.outputs.version }}-${{ matrix.rid }}.exe"
           else
             mv MermaidPad MermaidPad-${{ needs.get-version.outputs.version }}-${{ matrix.rid }}
             chmod +x MermaidPad-${{ needs.get-version.outputs.version }}-${{ matrix.rid }}
-            MAIN_BINARY="MermaidPad-${{ needs.get-version.outputs.version }}-${{ matrix.rid }}"
           fi
           ZIP_NAME="MermaidPad-${{ needs.get-version.outputs.version }}-${{ matrix.rid }}.zip"
           zip -r "$ZIP_NAME" ./*


### PR DESCRIPTION
Update artifact naming and zipping in release workflow

Refactor `build-and-release.yml` to correctly assign
`ARTIFACT_NAME` and `MAIN_BINARY` with version and
runtime identifier. Introduce `ZIP_NAME` for zipping
published artifacts, and update the upload step to
use `ZIP_NAME` for the artifact instead of `ARTIFACT_NAME`.