### PR TITLE
Fix workflow step ordering

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -200,12 +200,12 @@ jobs:
   bundle-macos-app:
     name: Bundle macOS .app
     needs: [restrict-user, get-version, build]
-    uses: ./.github/workflows/macos-bundle.yml
-    with:
-      version: ${{ needs.get-version.outputs.version }}
-      rid: ${{ matrix.rid }}
     strategy:
       matrix:
         include:
           - rid: osx-x64
           - rid: osx-arm64
+    uses: ./.github/workflows/macos-bundle.yml
+    with:
+      version: ${{ needs.get-version.outputs.version }}
+      rid: ${{ matrix.rid }}

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -73,6 +73,14 @@ jobs:
         run: |
           find MermaidPad.app
 
+      # Upload the .app bundle immediately after creation
+      - name: Upload .app bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app
+          path: MermaidPad.app
+
+      # Download the .app bundle artifact for zipping and release
       - name: Download .app bundle artifact
         uses: actions/download-artifact@v4
         with:
@@ -83,12 +91,6 @@ jobs:
         run: |
           cd ./artifacts/MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app
           zip -r ../MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip .
-
-      - name: Upload .app bundle artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app
-          path: MermaidPad.app
 
       - name: Upload .app bundle to the GitHub Release created by build-and-release.yml
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
Fix workflow step ordering

- Streamlined `build-and-release.yml` by removing unnecessary lines in the `macos-bundle` job.
- Added a new step in `macos-bundle.yml` to upload the `.app` bundle artifact immediately after creation.
- Removed the redundant previous upload step for the `.app` bundle.
- Improved overall workflow structure to ensure timely and correct artifact uploads.