### PR TITLE
Add permissions for osx-arm64 job in workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -209,3 +209,5 @@ jobs:
     with:
       version: ${{ needs.get-version.outputs.version }}
       rid: ${{ matrix.rid }}
+    permissions:
+      contents: write


### PR DESCRIPTION
Add permissions for osx-arm64 job in workflow

Added a new `permissions` section to the `osx-arm64` job in the `build-and-release.yml` file, granting write access to the contents.