### PR TITLE
Remove ad-hoc signing for macOS binaries

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -100,47 +100,47 @@ jobs:
       - name: Publish
         run: dotnet publish MermaidPad.csproj -c Release -r ${{ matrix.rid }} -o ./publish -p:Version=${{ needs.get-version.outputs.version }} -p:AssemblyVersion=${{ needs.get-version.outputs.version }} -p:FileVersion=${{ needs.get-version.outputs.version }}
       
-      # Add ad-hoc code signing for macOS binaries
-      - name: Ad-hoc Sign macOS Binary
-        if: ${{ matrix.rid == 'osx-x64' || matrix.rid == 'osx-arm64' }}
-        shell: bash
-        working-directory: ./publish
-        run: |
-          BIN_NAME="MermaidPad${{ matrix.extension }}"
-          echo "Ad-hoc signing macOS binary: $BIN_NAME"
+      # # Add ad-hoc code signing for macOS binaries
+      # - name: Ad-hoc Sign macOS Binary
+      #   if: ${{ matrix.rid == 'osx-x64' || matrix.rid == 'osx-arm64' }}
+      #   shell: bash
+      #   working-directory: ./publish
+      #   run: |
+      #     BIN_NAME="MermaidPad${{ matrix.extension }}"
+      #     echo "Ad-hoc signing macOS binary: $BIN_NAME"
           
-          # Ad-hoc sign the main executable
-          codesign --force --sign - "$BIN_NAME"
+      #     # Ad-hoc sign the main executable
+      #     codesign --force --sign - "$BIN_NAME"
           
-          # Verify the signing worked
-          codesign --verify --verbose "$BIN_NAME"
-          echo "Success: Ad-hoc signing completed for $BIN_NAME"
+      #     # Verify the signing worked
+      #     codesign --verify --verbose "$BIN_NAME"
+      #     echo "Success: Ad-hoc signing completed for $BIN_NAME"
           
-          # Sign .dylib files using find to avoid race conditions
-          echo "Searching for .dylib files to sign..."
-          DYLIB_COUNT=$(find . -name "*.dylib" -type f | wc -l)
+      #     # Sign .dylib files using find to avoid race conditions
+      #     echo "Searching for .dylib files to sign..."
+      #     DYLIB_COUNT=$(find . -name "*.dylib" -type f | wc -l)
           
-          if [ "$DYLIB_COUNT" -gt 0 ]; then
-            echo "Found $DYLIB_COUNT .dylib files, signing them..."
-            find . -name "*.dylib" -type f -print0 | while IFS= read -r -d '' file; do
-              if [ -f "$file" ]; then
-                echo "Signing: $file"
-                codesign --force --sign - "$file"
-                codesign --verify --verbose "$file"
-              else
-                echo "Warning: File disappeared during signing: $file"
-              fi
-            done
-            echo "Success: All .dylib files have been signed"
-          else
-            echo "No .dylib files found to sign"
-          fi
+      #     if [ "$DYLIB_COUNT" -gt 0 ]; then
+      #       echo "Found $DYLIB_COUNT .dylib files, signing them..."
+      #       find . -name "*.dylib" -type f -print0 | while IFS= read -r -d '' file; do
+      #         if [ -f "$file" ]; then
+      #           echo "Signing: $file"
+      #           codesign --force --sign - "$file"
+      #           codesign --verify --verbose "$file"
+      #         else
+      #           echo "Warning: File disappeared during signing: $file"
+      #         fi
+      #       done
+      #       echo "Success: All .dylib files have been signed"
+      #     else
+      #       echo "No .dylib files found to sign"
+      #     fi
           
-          # Clear any quarantine attributes that might have been set
-          echo "Clearing quarantine attributes..."
-          xattr -cr . || echo "No quarantine attributes to clear"
+      #     # Clear any quarantine attributes that might have been set
+      #     echo "Clearing quarantine attributes..."
+      #     xattr -cr . || echo "No quarantine attributes to clear"
           
-          echo "Success: All macOS binaries have been ad-hoc signed"
+      #     echo "Success: All macOS binaries have been ad-hoc signed"
 
       - name: Prepare artifact
         shell: bash
@@ -213,7 +213,7 @@ jobs:
             - macOS: WebKit (included on macOS by default - [Download](https://webkit.org/downloads/))
 
             ### macOS Installation Notes
-            **Important**: macOS binaries are ad-hoc signed. On first launch:
+            **Important**: macOS binaries are not signed. On first launch:
             1. Right-click the app -> **"Open"** (not double-click)
             2. Click **"Open"** when prompted about unidentified developer
             3. OR via terminal: `xattr -cr MermaidPad-*-osx-* && ./MermaidPad-*-osx-*`

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -69,48 +69,48 @@ jobs:
           cp Assets/AppIcon.icns "$BUNDLE/Contents/"
           chmod +x "$BUNDLE/Contents/MacOS/$APPNAME"
 
-      - name: Ad-hoc Sign .app Bundle
-        run: |
-          BUNDLE="MermaidPad.app"
-          echo "Starting comprehensive ad-hoc signing of $BUNDLE"
+      # - name: Ad-hoc Sign .app Bundle
+      #   run: |
+      #     BUNDLE="MermaidPad.app"
+      #     echo "Starting comprehensive ad-hoc signing of $BUNDLE"
           
-          # Sign all dylibs and frameworks first (inside-out approach)
-          echo "Signing dynamic libraries and frameworks..."
-          find "$BUNDLE" -name "*.dylib" -exec codesign --force --sign - {} \; || echo "No .dylib files found"
-          find "$BUNDLE" -name "*.framework" -exec codesign --force --sign - {} \; || echo "No .framework files found"
+      #     # Sign all dylibs and frameworks first (inside-out approach)
+      #     echo "Signing dynamic libraries and frameworks..."
+      #     find "$BUNDLE" -name "*.dylib" -exec codesign --force --sign - {} \; || echo "No .dylib files found"
+      #     find "$BUNDLE" -name "*.framework" -exec codesign --force --sign - {} \; || echo "No .framework files found"
           
-          # Sign the main executable
-          echo "Signing main executable..."
-          codesign --force --sign - "$BUNDLE/Contents/MacOS/MermaidPad"
+      #     # Sign the main executable
+      #     echo "Signing main executable..."
+      #     codesign --force --sign - "$BUNDLE/Contents/MacOS/MermaidPad"
           
-          # Sign the entire bundle with --deep to catch anything we missed
-          echo "Signing entire .app bundle..."
-          codesign --force --deep --sign - "$BUNDLE"
+      #     # Sign the entire bundle with --deep to catch anything we missed
+      #     echo "Signing entire .app bundle..."
+      #     codesign --force --deep --sign - "$BUNDLE"
           
-          # Verify the signing worked
-          echo "Verifying signatures..."
-          codesign --verify --deep --strict --verbose=2 "$BUNDLE" || {
-            echo "ERROR: Signature verification failed"
-            exit 1
-          }
+      #     # Verify the signing worked
+      #     echo "Verifying signatures..."
+      #     codesign --verify --deep --strict --verbose=2 "$BUNDLE" || {
+      #       echo "ERROR: Signature verification failed"
+      #       exit 1
+      #     }
           
-          # Check Gatekeeper assessment (what users will experience)
-          echo "Testing Gatekeeper assessment..."
-          spctl --assess --type execute --verbose "$BUNDLE" || {
-            echo "Gatekeeper assessment failed (expected for ad-hoc signed apps)"
-            echo "   Users will need to right-click -> Open on first launch"
-          }
+      #     # Check Gatekeeper assessment (what users will experience)
+      #     echo "Testing Gatekeeper assessment..."
+      #     spctl --assess --type execute --verbose "$BUNDLE" || {
+      #       echo "Gatekeeper assessment failed (expected for ad-hoc signed apps)"
+      #       echo "   Users will need to right-click -> Open on first launch"
+      #     }
           
-          # Clear any quarantine attributes
-          echo "Clearing quarantine attributes..."
-          xattr -cr "$BUNDLE" || echo "No quarantine attributes to clear"
+      #     # Clear any quarantine attributes
+      #     echo "Clearing quarantine attributes..."
+      #     xattr -cr "$BUNDLE" || echo "No quarantine attributes to clear"
           
-          # List final app structure for debugging
-          echo "Final app bundle structure:"
-          find "$BUNDLE" -type f | head -100
-          echo "   ... (showing first 100 files)"
+      #     # List final app structure for debugging
+      #     echo "Final app bundle structure:"
+      #     find "$BUNDLE" -type f | head -100
+      #     echo "   ... (showing first 100 files)"
 
-          echo "Success: Ad-hoc signing completed successfully!"
+      #     echo "Success: Ad-hoc signing completed successfully!"
 
       - name: List .app bundle contents
         run: |

--- a/.github/workflows/macos-universal-dmg.yml
+++ b/.github/workflows/macos-universal-dmg.yml
@@ -118,12 +118,12 @@ jobs:
           # Make sure it's executable
           chmod +x ./universal/MermaidPad.app/Contents/MacOS/MermaidPad
           
-          # Sign the universal binary (ad-hoc signing)
-          echo "Ad-hoc signing universal app bundle..."
-          codesign --force --deep --sign - ./universal/MermaidPad.app
+          # # Sign the universal binary (ad-hoc signing)
+          # echo "Ad-hoc signing universal app bundle..."
+          # codesign --force --deep --sign - ./universal/MermaidPad.app
           
-          # Verify the signing
-          codesign --verify --deep --strict --verbose=2 ./universal/MermaidPad.app
+          # # Verify the signing
+          # codesign --verify --deep --strict --verbose=2 ./universal/MermaidPad.app
           
           echo "Universal app bundle structure:"
           ls -la ./universal/MermaidPad.app/Contents/
@@ -143,7 +143,6 @@ jobs:
           ICON_PATH="$(realpath ./Assets/AppIcon.icns 2>/dev/null)"
           if [ -f "$ICON_PATH" ]; then
             echo "Using custom volume icon: $ICON_PATH"
-            ICON_PARAM="--volicon \"$ICON_PATH\""
           else
             echo "ERROR: AppIcon.icns not found at ./Assets/AppIcon.icns"
             echo "Available files in Assets directory:"


### PR DESCRIPTION
Remove ad-hoc signing for macOS binaries

Comment out signing commands and verification steps in YAML files. Update documentation to reflect that macOS binaries are not signed on first launch and provide user instructions for opening the app. This change indicates a shift away from ad-hoc signing in the build and release process.