### PR TITLE
Update .editorconfig and improve .app bundle zipping process

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ indent_style = space
 indent_size = 2
 tab_width = 2
 
-﻿[*.cs]
+[*.cs]
 
 #### Core EditorConfig Options ####
 
@@ -65,6 +65,16 @@ csharp_indent_labels = one_less_than_current
 
 # IDE0079: Remove unnecessary suppression
 dotnet_diagnostic.IDE0079.severity = none
+csharp_style_throw_expression = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true:error
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:error
+csharp_style_prefer_index_operator = true:warning
+csharp_style_prefer_range_operator = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_prefer_implicitly_typed_lambda_expression = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_space_around_binary_operators = before_and_after
 
 [*.{cs,vb}]
 #### Naming styles ####
@@ -126,3 +136,10 @@ tab_width = 4
 indent_size = 4
 end_of_line = crlf
 dotnet_style_prefer_conditional_expression_over_return = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:warning
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion
+dotnet_style_namespace_match_folder = true:suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,11 @@
+﻿# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+tab_width = 2
+
 ﻿[*.cs]
 
 #### Core EditorConfig Options ####

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -146,11 +146,12 @@ jobs:
         shell: bash
         working-directory: ./publish
         run: |
+          set -euo pipefail
           ZIP_NAME="MermaidPad-${{ needs.get-version.outputs.version }}-${{ matrix.rid }}.zip"
           BIN_NAME="MermaidPad${{ matrix.extension }}"
           if [ "${{ matrix.extension }}" != ".exe" ]; then
             chmod +x "$BIN_NAME"
-            zip -r "$ZIP_NAME" ./*
+            zip -r "$ZIP_NAME" ./* -x "*.DS_Store*"
           else
             powershell.exe -Command "Compress-Archive -Path * -DestinationPath $ZIP_NAME"
           fi
@@ -176,8 +177,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
         if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -199,7 +200,8 @@ jobs:
         with:
           tag: v${{ needs.get-version.outputs.version }}
           name: MermaidPad v${{ needs.get-version.outputs.version }}
-          artifacts: "./artifacts/**/*"
+          # Restrict to actual files; avoids "Artifact is a directory" warnings
+          artifacts: "./artifacts/**/*.zip"
           generateReleaseNotes: true
           allowUpdates: true
           prerelease: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.is_preview == 'true' }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -177,8 +177,8 @@ jobs:
 
     steps:
       - name: Checkout
-        if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v4
+        if: github.event_name == 'workflow_dispatch'
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -134,8 +134,8 @@ jobs:
         run: |
           cd ./artifacts
           
-          # Find the exact MermaidPad.app bundle
-          APP_BUNDLES=($(find . -name "MermaidPad.app" -type d))
+          # Find the exact MermaidPad.app bundle using robust array assignment
+          mapfile -t APP_BUNDLES < <(find . -name "MermaidPad.app" -type d)
           
           # Validate exactly one .app bundle exists
           if [ ${#APP_BUNDLES[@]} -eq 0 ]; then
@@ -156,7 +156,7 @@ jobs:
           
           # Create zip preserving executable permissions with correct exclusion patterns
           zip -r "MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip" "$APP_BUNDLE" \
-              -x "**/.DS_Store" "__MACOSX/*"
+              -x "*.DS_Store" "*/.DS_Store" "__MACOSX/*"
           
           echo "Success: Created app bundle zip: MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip"
 

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -135,9 +135,9 @@ jobs:
         run: |
           cd ./artifacts
           
-          # Find the exact MermaidPad.app bundle using robust array assignment:
-          # This approach (readarray with process substitution) safely handles filenames with spaces or newlines,
-          # avoids word splitting issues, and ensures each result is a separate array element.
+          # Find MermaidPad.app bundle in current directory
+          
+          
           readarray -t APP_BUNDLES < <(find . -name "MermaidPad.app" -type d)
           
           # Validate exactly one .app bundle exists

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -132,22 +132,24 @@ jobs:
 
       - name: Zip .app bundle for release
         run: |
-          # Verify the downloaded structure
-          echo "Downloaded artifact structure:"
-          ls -la ./artifacts/
-
           cd ./artifacts
-        
-          # Find the actual .app bundle (it should be directly here)
-          APP_BUNDLE=$(find . -name "*.app" -type d | head -1)
     
-          if [ -z "$APP_BUNDLE" ]; then
-            echo "ERROR: Could not find .app bundle"
+          # Find MermaidPad .app bundles specifically
+          APP_BUNDLES=($(find . -name "MermaidPad*.app" -type d))
+    
+          # Validate exactly one .app bundle exists
+          if [ ${#APP_BUNDLES[@]} -eq 0 ]; then
+            echo "ERROR: Could not find MermaidPad .app bundle"
             ls -la .
+            exit 1
+          elif [ ${#APP_BUNDLES[@]} -gt 1 ]; then
+            echo "ERROR: Multiple MermaidPad .app bundles found:"
+            printf '%s\n' "${APP_BUNDLES[@]}"
             exit 1
           fi
     
-          echo "Found: $APP_BUNDLE"
+          APP_BUNDLE="${APP_BUNDLES[0]}"
+          echo "Found app bundle: $APP_BUNDLE"
     
           # Ensure all files have correct permissions before zipping
           find "$APP_BUNDLE" -type f -name "MermaidPad" -exec chmod +x {} \;

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -141,13 +141,10 @@ jobs:
           readarray -t APP_BUNDLES < <(find . -name "MermaidPad.app" -type d)
           
           # Validate exactly one .app bundle exists
-          if [ ${#APP_BUNDLES[@]} -eq 0 ]; then
-            echo "ERROR: Could not find MermaidPad.app bundle"
-            ls -la .
-            exit 1
-          elif [ ${#APP_BUNDLES[@]} -gt 1 ]; then
-            echo "ERROR: Multiple MermaidPad.app bundles found:"
+          if [ ${#APP_BUNDLES[@]} -ne 1 ]; then
+            echo "ERROR: Expected exactly one MermaidPad.app bundle, found ${#APP_BUNDLES[@]}:"
             printf '%s\n' "${APP_BUNDLES[@]}"
+            ls -la .
             exit 1
           fi
           

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -133,31 +133,31 @@ jobs:
       - name: Zip .app bundle for release
         run: |
           cd ./artifacts
-    
-          # Find MermaidPad .app bundles specifically
-          APP_BUNDLES=($(find . -name "MermaidPad*.app" -type d))
-    
+          
+          # Find the exact MermaidPad.app bundle
+          APP_BUNDLES=($(find . -name "MermaidPad.app" -type d))
+          
           # Validate exactly one .app bundle exists
           if [ ${#APP_BUNDLES[@]} -eq 0 ]; then
-            echo "ERROR: Could not find MermaidPad .app bundle"
+            echo "ERROR: Could not find MermaidPad.app bundle"
             ls -la .
             exit 1
           elif [ ${#APP_BUNDLES[@]} -gt 1 ]; then
-            echo "ERROR: Multiple MermaidPad .app bundles found:"
+            echo "ERROR: Multiple MermaidPad.app bundles found:"
             printf '%s\n' "${APP_BUNDLES[@]}"
             exit 1
           fi
-    
+          
           APP_BUNDLE="${APP_BUNDLES[0]}"
           echo "Found app bundle: $APP_BUNDLE"
-    
+          
           # Ensure all files have correct permissions before zipping
           find "$APP_BUNDLE" -type f -name "MermaidPad" -exec chmod +x {} \;
-    
+          
           # Create zip preserving executable permissions with correct exclusion patterns
           zip -r "MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip" "$APP_BUNDLE" \
-              -x "*.DS_Store" "__MACOSX/*"
-    
+              -x "**/.DS_Store" "__MACOSX/*"
+          
           echo "Success: Created app bundle zip: MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip"
 
       - name: Upload .app bundle to the GitHub Release created by build-and-release.yml

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -136,7 +136,7 @@ jobs:
           cd ./artifacts
           
           # Find the exact MermaidPad.app bundle using robust array assignment
-          mapfile -t APP_BUNDLES < <(find . -name "MermaidPad.app" -type d)
+          APP_BUNDLES=($(find . -name "MermaidPad.app" -type d))
           
           # Validate exactly one .app bundle exists
           if [ ${#APP_BUNDLES[@]} -eq 0 ]; then

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -136,8 +136,6 @@ jobs:
           cd ./artifacts
           
           # Find MermaidPad.app bundle in current directory
-          
-          
           readarray -t APP_BUNDLES < <(find . -name "MermaidPad.app" -type d)
           
           # Validate exactly one .app bundle exists

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -155,8 +155,7 @@ jobs:
           # Ensure all files have correct permissions before zipping
           find "$APP_BUNDLE" -type f -name "MermaidPad" -exec chmod +x {} \;
           
-          # Create zip preserving executable permissions with correct exclusion patterns
-              -x "*.DS_Store*" "__MACOSX/*"
+          zip -r "MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip" "$APP_BUNDLE" -x "*.DS_Store*" "__MACOSX/*"
           
           echo "Success: Created app bundle zip: MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip"
 

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -136,7 +136,7 @@ jobs:
           cd ./artifacts
           
           # Find the exact MermaidPad.app bundle using robust array assignment
-          APP_BUNDLES=($(find . -name "MermaidPad.app" -type d))
+          readarray -t APP_BUNDLES < <(find . -name "MermaidPad.app" -type d)
           
           # Validate exactly one .app bundle exists
           if [ ${#APP_BUNDLES[@]} -eq 0 ]; then

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -135,7 +135,9 @@ jobs:
         run: |
           cd ./artifacts
           
-          # Find the exact MermaidPad.app bundle using robust array assignment
+          # Find the exact MermaidPad.app bundle using robust array assignment:
+          # This approach (readarray with process substitution) safely handles filenames with spaces or newlines,
+          # avoids word splitting issues, and ensures each result is a separate array element.
           readarray -t APP_BUNDLES < <(find . -name "MermaidPad.app" -type d)
           
           # Validate exactly one .app bundle exists

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -131,6 +131,7 @@ jobs:
           path: ./artifacts
 
       - name: Zip .app bundle for release
+        shell: bash
         run: |
           cd ./artifacts
           

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Create .app bundle structure
         run: |
+          set -euo pipefail
           APPNAME="MermaidPad"
           BUNDLE="MermaidPad.app"
           mkdir -p "$BUNDLE/Contents/MacOS"
@@ -133,27 +134,24 @@ jobs:
       - name: Zip .app bundle for release
         shell: bash
         run: |
+          set -euo pipefail
           cd ./artifacts
-          
-          # Find MermaidPad.app bundle in current directory
-          readarray -t APP_BUNDLES < <(find . -name "MermaidPad.app" -type d)
-          
-          # Validate exactly one .app bundle exists
-            printf '%s\n' "${APP_BUNDLES[@]}"
-            echo "Current working directory: $(pwd)"
-            ls -la .
+          # Find exactly one MermaidPad.app anywhere under artifacts
+          mapfile -t APP_BUNDLES < <(find . -type d -name "MermaidPad.app")
+          printf '%s\n' "${APP_BUNDLES[@]}"
+          if [ "${#APP_BUNDLES[@]}" -ne 1 ]; then
+            echo "ERROR: Expected exactly one MermaidPad.app, found ${#APP_BUNDLES[@]}"
+            find . -maxdepth 4 -type d -name "MermaidPad.app" -print
             exit 1
           fi
-          
           APP_BUNDLE="${APP_BUNDLES[0]}"
           echo "Found app bundle: $APP_BUNDLE"
-          
-          # Ensure all files have correct permissions before zipping
+          # Ensure main binary is executable
           find "$APP_BUNDLE" -type f -name "MermaidPad" -exec chmod +x {} \;
-          
-          zip -r "MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip" "$APP_BUNDLE" -x "*.DS_Store*" "__MACOSX/*"
-          
-          echo "Success: Created app bundle zip: MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip"
+          # Create the zip at artifacts root
+          ZIP_NAME="MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip"
+          zip -r "$ZIP_NAME" "$APP_BUNDLE" -x "*.DS_Store*" "__MACOSX/*"
+          echo "Success: Created app bundle zip: $ZIP_NAME"
 
       - name: Upload .app bundle to the GitHub Release created by build-and-release.yml
         uses: ncipollo/release-action@v1

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -132,14 +132,29 @@ jobs:
 
       - name: Zip .app bundle for release
         run: |
-          cd ./artifacts/MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app
-          
+          # Verify the downloaded structure
+          echo "Downloaded artifact structure:"
+          ls -la ./artifacts/
+
+          cd ./artifacts
+        
+          # Find the actual .app bundle (it should be directly here)
+          APP_BUNDLE=$(find . -name "*.app" -type d | head -1)
+    
+          if [ -z "$APP_BUNDLE" ]; then
+            echo "ERROR: Could not find .app bundle"
+            ls -la .
+            exit 1
+          fi
+    
+          echo "Found: $APP_BUNDLE"
+    
           # Ensure all files have correct permissions before zipping
-          find . -type f -name "MermaidPad" -exec chmod +x {} \;
-          
-          # Create zip preserving executable permissions
-          zip -r ../MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip . -x "*.DS_Store*" "__MACOSX/*"
-          
+          find "$APP_BUNDLE" -type f -name "MermaidPad" -exec chmod +x {} \;
+    
+          # Create zip preserving executable permissions  
+          zip -r "MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip" "$APP_BUNDLE" -x "*.DS_Store*" "*/__MACOSX*"
+    
           echo "Success: Created app bundle zip: MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip"
 
       - name: Upload .app bundle to the GitHub Release created by build-and-release.yml

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -152,8 +152,9 @@ jobs:
           # Ensure all files have correct permissions before zipping
           find "$APP_BUNDLE" -type f -name "MermaidPad" -exec chmod +x {} \;
     
-          # Create zip preserving executable permissions  
-          zip -r "MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip" "$APP_BUNDLE" -x "*.DS_Store*" "*/__MACOSX*"
+          # Create zip preserving executable permissions with correct exclusion patterns
+          zip -r "MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip" "$APP_BUNDLE" \
+              -x "*.DS_Store" "__MACOSX/*"
     
           echo "Success: Created app bundle zip: MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip"
 

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -156,8 +156,7 @@ jobs:
           find "$APP_BUNDLE" -type f -name "MermaidPad" -exec chmod +x {} \;
           
           # Create zip preserving executable permissions with correct exclusion patterns
-          zip -r "MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip" "$APP_BUNDLE" \
-              -x "*.DS_Store" "__MACOSX/*"
+              -x "*.DS_Store*" "__MACOSX/*"
           
           echo "Success: Created app bundle zip: MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip"
 

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -157,7 +157,7 @@ jobs:
           
           # Create zip preserving executable permissions with correct exclusion patterns
           zip -r "MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip" "$APP_BUNDLE" \
-              -x "*.DS_Store" "*/.DS_Store" "__MACOSX/*"
+              -x "*.DS_Store" "__MACOSX/*"
           
           echo "Success: Created app bundle zip: MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip"
 

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -139,9 +139,8 @@ jobs:
           readarray -t APP_BUNDLES < <(find . -name "MermaidPad.app" -type d)
           
           # Validate exactly one .app bundle exists
-          if [ ${#APP_BUNDLES[@]} -ne 1 ]; then
-            echo "ERROR: Expected exactly one MermaidPad.app bundle, found ${#APP_BUNDLES[@]}:"
             printf '%s\n' "${APP_BUNDLES[@]}"
+            echo "Current working directory: $(pwd)"
             ls -la .
             exit 1
           fi


### PR DESCRIPTION
Enhance .editorconfig for YAML and C# settings, ensuring consistent code style. Fix the zipping process for the .app bundle in macos-bundle.yml by adding `shell: bash`