### PR TITLE
change shell for Zip .app bundle for release step to bash

### DIFF
--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -132,6 +132,7 @@ jobs:
           path: ./artifacts
 
       - name: Zip .app bundle for release
+        shell: bash
         run: |
           set -euo pipefail
           cd ./artifacts


### PR DESCRIPTION
change shell for Zip .app bundle for release step to bash