### PR TITLE
Update macos-bundle.yml for signing and zipping process

### DIFF
--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -74,38 +74,38 @@ jobs:
       #   run: |
       #     BUNDLE="MermaidPad.app"
       #     echo "Starting comprehensive ad-hoc signing of $BUNDLE"
-          
+      #     
       #     # Sign all dylibs and frameworks first (inside-out approach)
       #     echo "Signing dynamic libraries and frameworks..."
       #     find "$BUNDLE" -name "*.dylib" -exec codesign --force --sign - {} \; || echo "No .dylib files found"
       #     find "$BUNDLE" -name "*.framework" -exec codesign --force --sign - {} \; || echo "No .framework files found"
-          
+      #     
       #     # Sign the main executable
       #     echo "Signing main executable..."
       #     codesign --force --sign - "$BUNDLE/Contents/MacOS/MermaidPad"
-          
+      #     
       #     # Sign the entire bundle with --deep to catch anything we missed
       #     echo "Signing entire .app bundle..."
       #     codesign --force --deep --sign - "$BUNDLE"
-          
+      #     
       #     # Verify the signing worked
       #     echo "Verifying signatures..."
       #     codesign --verify --deep --strict --verbose=2 "$BUNDLE" || {
       #       echo "ERROR: Signature verification failed"
       #       exit 1
       #     }
-          
+      #     
       #     # Check Gatekeeper assessment (what users will experience)
       #     echo "Testing Gatekeeper assessment..."
       #     spctl --assess --type execute --verbose "$BUNDLE" || {
       #       echo "Gatekeeper assessment failed (expected for ad-hoc signed apps)"
       #       echo "   Users will need to right-click -> Open on first launch"
       #     }
-          
+      #     
       #     # Clear any quarantine attributes
       #     echo "Clearing quarantine attributes..."
       #     xattr -cr "$BUNDLE" || echo "No quarantine attributes to clear"
-          
+      #     
       #     # List final app structure for debugging
       #     echo "Final app bundle structure:"
       #     find "$BUNDLE" -type f | head -100
@@ -136,21 +136,34 @@ jobs:
         run: |
           set -euo pipefail
           cd ./artifacts
-          # Find exactly one MermaidPad.app anywhere under artifacts
-          mapfile -t APP_BUNDLES < <(find . -type d -name "MermaidPad.app")
+
+          # Collect .app bundles (expect exactly one)
+          APP_BUNDLES=()
+          while IFS= read -r -d '' line; do
+            APP_BUNDLES+=("$line")
+          done < <(find . -type d -name "MermaidPad.app" -print0 2>/dev/null)
+
           printf '%s\n' "${APP_BUNDLES[@]}"
           if [ "${#APP_BUNDLES[@]}" -ne 1 ]; then
             echo "ERROR: Expected exactly one MermaidPad.app, found ${#APP_BUNDLES[@]}"
+            # Limit debug search to a shallow tree for speed and concise logs.
+            # maxdepth 4 comfortably covers expected layouts like:
+            #   ./<artifact-name>/MermaidPad.app            (depth ~2)
+            #   ./<artifact-name>/<extra>/.../MermaidPad.app (depth <=4)
+            # This avoids traversing large trees under ./artifacts when something is off.
             find . -maxdepth 4 -type d -name "MermaidPad.app" -print
             exit 1
           fi
+
           APP_BUNDLE="${APP_BUNDLES[0]}"
           echo "Found app bundle: $APP_BUNDLE"
+
           # Ensure main binary is executable
           find "$APP_BUNDLE" -type f -name "MermaidPad" -exec chmod +x {} \;
-          # Create the zip at artifacts root
+
+          # Create macOS-friendly zip (preserves metadata, no __MACOSX)
           ZIP_NAME="MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip"
-          zip -r "$ZIP_NAME" "$APP_BUNDLE" -x "*.DS_Store*" "__MACOSX/*"
+          ditto -c -k --sequesterRsrc --keepParent "$APP_BUNDLE" "$ZIP_NAME"
           echo "Success: Created app bundle zip: $ZIP_NAME"
 
       - name: Upload .app bundle to the GitHub Release created by build-and-release.yml


### PR DESCRIPTION
Update macos-bundle.yml for signing and zipping process

Comment out signing steps and enhance zipping logic for
MermaidPad.app. Improved error handling ensures exactly one
app bundle is found, and switched to using `ditto` for
creating the zip file to preserve metadata and avoid
__MACOSX directory.