### PR TITLE
Another attempt to fix workflow build process for macOS applications

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -177,8 +177,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
         if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -143,9 +143,11 @@ jobs:
             APP_BUNDLES+=("$line")
           done < <(find . -type d -name "MermaidPad.app" -print0 2>/dev/null)
 
-          printf '%s\n' "${APP_BUNDLES[@]}"
-          if [ "${#APP_BUNDLES[@]}" -ne 1 ]; then
-            echo "ERROR: Expected exactly one MermaidPad.app, found ${#APP_BUNDLES[@]}"
+          printf '%s\n' "${APP_BUNDLES[@]:-}"
+
+          if [ "${#APP_BUNDLES[@]:-0}" -ne 1 ]; then
+            echo "ERROR: Expected exactly one MermaidPad.app, found ${#APP_BUNDLES[@]:-0}"
+
             # Limit debug search to a shallow tree for speed and concise logs.
             # maxdepth 4 comfortably covers expected layouts like:
             #   ./<artifact-name>/MermaidPad.app            (depth ~2)

--- a/.github/workflows/macos-universal-dmg-perplexity.yml
+++ b/.github/workflows/macos-universal-dmg-perplexity.yml
@@ -1,0 +1,173 @@
+﻿# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Create Universal macOS DMG
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to create universal DMG for (e.g., 1.0.0)'
+        required: true
+        type: string
+
+jobs:
+  restrict-user:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Restrict to allowed user
+        run: |
+          if [ "${{ github.actor }}" != "udlose" ]; then
+            echo "Only udlose can run this workflow."
+            exit 1
+          fi
+
+  create-universal-dmg:
+    name: Create Universal macOS DMG
+    needs: restrict-user
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Download .app bundle artifacts that were uploaded by macos-bundle.yml
+      - name: Download macOS x64 app bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: MermaidPad-${{ inputs.version }}-osx-x64.app
+          path: ./artifacts/x64-app
+
+      - name: Download macOS ARM64 app bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: MermaidPad-${{ inputs.version }}-osx-arm64.app
+          path: ./artifacts/arm64-app
+
+      - name: Verify downloaded app bundles
+        run: |
+          set -euo pipefail
+          echo "Downloaded app bundles:"
+          ls -la ./artifacts/x64-app/ || true
+          ls -la ./artifacts/arm64-app/ || true
+          echo "App bundle contents:"
+          find ./artifacts/x64-app/ -name "*.app" -maxdepth 4 -exec ls -la {} \; || true
+          find ./artifacts/arm64-app/ -name "*.app" -maxdepth 4 -exec ls -la {} \; || true
+
+      - name: Create Universal Binary
+        run: |
+          set -euo pipefail
+          # Find the .app bundles in the downloaded artifacts
+          X64_APP=$(find ./artifacts/x64-app -name "*.app" -type d | head -1 || true)
+          ARM64_APP=$(find ./artifacts/arm64-app -name "*.app" -type d | head -1 || true)
+          echo "X64 app bundle: $X64_APP"
+          echo "ARM64 app bundle: $ARM64_APP"
+          if [ -z "${X64_APP}" ] || [ -z "${ARM64_APP}" ]; then
+            echo "ERROR: Could not find app bundles"
+            echo "X64 directory contents:"; ls -la ./artifacts/x64-app/ || true
+            echo "ARM64 directory contents:"; ls -la ./artifacts/arm64-app/ || true
+            exit 1
+          fi
+
+          # Create the universal app bundle by copying the x64 structure
+          mkdir -p "./universal"
+          rm -rf "./universal/MermaidPad.app"
+          cp -R "$X64_APP" "./universal/MermaidPad.app"
+
+          # Verify we have the binaries
+          X64_BINARY="$X64_APP/Contents/MacOS/MermaidPad"
+          ARM64_BINARY="$ARM64_APP/Contents/MacOS/MermaidPad"
+          echo "X64 binary: $X64_BINARY"
+          echo "ARM64 binary: $ARM64_BINARY"
+          if [ ! -f "$X64_BINARY" ] || [ ! -f "$ARM64_BINARY" ]; then
+            echo "ERROR: Could not find binaries in app bundles"
+            echo "X64 contents:"; ls -la "$X64_APP/Contents/MacOS/" || echo "X64 MacOS directory not found"
+            echo "ARM64 contents:"; ls -la "$ARM64_APP/Contents/MacOS/" || echo "ARM64 MacOS directory not found"
+            exit 1
+          fi
+
+          echo "Verifying individual binaries:"
+          lipo -info "$X64_BINARY" || true
+          lipo -info "$ARM64_BINARY" || true
+
+          echo "Creating universal binary..."
+          lipo -create \
+            "$X64_BINARY" \
+            "$ARM64_BINARY" \
+            -output ./universal/MermaidPad.app/Contents/MacOS/MermaidPad
+
+          echo "Universal binary info:"
+          lipo -info ./universal/MermaidPad.app/Contents/MacOS/MermaidPad
+          chmod +x ./universal/MermaidPad.app/Contents/MacOS/MermaidPad
+
+          echo "Universal app bundle structure:"
+          ls -la ./universal/MermaidPad.app/Contents/ || true
+
+      - name: Install create-dmg
+        run: |
+          brew install create-dmg
+
+      - name: Create DMG
+        run: |
+          set -euo pipefail
+          mkdir -p ./dmg-staging
+          cp -R ./universal/MermaidPad.app ./dmg-staging/
+
+          ICON_PATH="$(realpath ./Assets/AppIcon.icns 2>/dev/null || true)"
+          if [ -f "$ICON_PATH" ]; then
+            echo "Using custom volume icon: $ICON_PATH"
+          else
+            echo "ERROR: AppIcon.icns not found at ./Assets/AppIcon.icns"
+            echo "Available files in Assets directory:"
+            ls -la ./Assets/ || echo "Assets directory not found"
+            exit 1
+          fi
+
+          create-dmg \
+            --volname "MermaidPad" \
+            --volicon "$ICON_PATH" \
+            --window-pos 200 120 \
+            --window-size 800 400 \
+            --icon-size 100 \
+            --icon "MermaidPad.app" 200 190 \
+            --hide-extension "MermaidPad.app" \
+            --app-drop-link 600 185 \
+            --disk-image-size 200 \
+            --format UDZO \
+            "MermaidPad-${{ inputs.version }}-universal.dmg" \
+            "./dmg-staging"
+
+      - name: Verify DMG
+        run: |
+          set -euo pipefail
+          ls -la "MermaidPad-${{ inputs.version }}-universal.dmg"
+          echo "DMG file size: $(du -h MermaidPad-${{ inputs.version }}-universal.dmg)"
+          echo "Mounting DMG for verification..."
+          hdiutil attach "MermaidPad-${{ inputs.version }}-universal.dmg" -readonly -mountpoint /tmp/mermaid-verify
+          echo "DMG Contents:"
+          ls -la /tmp/mermaid-verify/
+          echo "Verifying universal binary inside DMG:"
+          if [ -f "/tmp/mermaid-verify/MermaidPad.app/Contents/MacOS/MermaidPad" ]; then
+            lipo -info "/tmp/mermaid-verify/MermaidPad.app/Contents/MacOS/MermaidPad"
+            echo "SUCCESS: Universal binary verified inside DMG"
+          else
+            echo "ERROR: Could not find MermaidPad binary inside mounted DMG"
+            ls -la "/tmp/mermaid-verify/MermaidPad.app/Contents/MacOS/" || echo "MacOS directory not found"
+            hdiutil detach /tmp/mermaid-verify || true
+            exit 1
+          fi
+          echo "Unmounting DMG..."
+          hdiutil detach /tmp/mermaid-verify
+          echo "SUCCESS: DMG verification completed"
+
+      - name: Upload Universal DMG to Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: v${{ inputs.version }}
+          artifacts: "MermaidPad-${{ inputs.version }}-universal.dmg"
+          allowUpdates: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/MermaidPad.csproj
+++ b/MermaidPad.csproj
@@ -97,6 +97,7 @@
 
 	<ItemGroup>
 		<None Include=".github\workflows\build-and-release.yml" />
+		<None Include=".github\workflows\macos-universal-dmg-perplexity.yml" />
 		<None Include=".github\workflows\macos-universal-dmg.yml" />
 		<None Include=".github\workflows\macos-bundle.yml" />
 	</ItemGroup>


### PR DESCRIPTION
#### PR Classification
Another attempt to fix workflow build process for macOS applications.

#### PR Summary
This pull request introduces a new workflow for creating a universal macOS DMG and updates existing workflows to improve artifact handling and error reporting. 
- `build-and-release.yml`: Added a step to download artifacts and specified permissions for writing contents.
- `macos-bundle.yml`: Modified error message handling for checking `MermaidPad.app` bundles to improve robustness.
- `macos-universal-dmg-perplexity.yml`: Added a new workflow for creating a universal macOS DMG with user restrictions and enhanced logging.
- `MermaidPad.csproj`: Included the new `macos-universal-dmg-perplexity.yml` workflow in the project.
