### PR TITLE
Update macOS app bundle workflow to use zipped files

### DIFF
--- a/.github/workflows/macos-universal-dmg.yml
+++ b/.github/workflows/macos-universal-dmg.yml
@@ -40,14 +40,22 @@ jobs:
       - name: Download macOS x64 app bundle
         uses: actions/download-artifact@v4
         with:
-          name: MermaidPad-${{ inputs.version }}-osx-x64.app
+          name: MermaidPad-${{ inputs.version }}-osx-x64.app.zip
           path: ./artifacts/x64-app
 
       - name: Download macOS ARM64 app bundle  
         uses: actions/download-artifact@v4
         with:
-          name: MermaidPad-${{ inputs.version }}-osx-arm64.app
+          name: MermaidPad-${{ inputs.version }}-osx-arm64.app.zip
           path: ./artifacts/arm64-app
+
+      - name: Unzip x64 app bundle
+        run: |
+          unzip ./artifacts/x64-app/MermaidPad-${{ inputs.version }}-osx-x64.app.zip -d ./artifacts/x64-app/
+
+      - name: Unzip arm64 app bundle
+        run: |
+          unzip ./artifacts/arm64-app/MermaidPad-${{ inputs.version }}-osx-arm64.app.zip -d ./artifacts/arm64-app/
 
       - name: Verify downloaded app bundles
         run: |
@@ -61,9 +69,9 @@ jobs:
 
       - name: Create Universal Binary
         run: |
-          # Find the .app bundles in the downloaded artifacts
-          X64_APP=$(find ./artifacts/x64-app -name "*.app" -type d | head -1)
-          ARM64_APP=$(find ./artifacts/arm64-app -name "*.app" -type d | head -1)
+          # Use the .app bundles in the downloaded artifacts
+          X64_APP="./artifacts/x64-app/MermaidPad.app"
+          ARM64_APP="./artifacts/arm64-app/MermaidPad.app"
           
           echo "X64 app bundle: $X64_APP"
           echo "ARM64 app bundle: $ARM64_APP"


### PR DESCRIPTION
Update macOS app bundle workflow to use zipped files

This commit modifies the `macos-universal-dmg.yml` workflow to download zipped versions of macOS app bundles instead of unzipped `.app` files. It adds steps to unzip these files into their respective directories for x64 and ARM64 architectures. The method for identifying app bundles has been updated to directly reference the expected paths, simplifying the process by assuming a consistent naming convention.