### PR TITLE
Remove extraneous ncipollo/release-action step done in macos-bundle.yml that was overwriting the one in build-and-release.yml. Update artifact handling for macOS bundles

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -185,18 +185,18 @@ jobs:
         with:
           path: ./artifacts
 
-      # This will download MermaidPad-<version>-osx-x64.app from macos-bundle.yml
+      # Download macOS .app bundle zip (x64)
       - name: Download macOS .app bundle zip (x64)
         uses: actions/download-artifact@v4
         with:
-          name: MermaidPad-${{ needs.get-version.outputs.version }}-osx-x64.app
+          name: MermaidPad-${{ needs.get-version.outputs.version }}-osx-x64.app.zip
           path: ./artifacts-app
 
-      # This will download MermaidPad-<version>-osx-arm64.app from macos-bundle.yml
+      # Download macOS .app bundle zip (arm64)
       - name: Download macOS .app bundle zip (arm64)
         uses: actions/download-artifact@v4
         with:
-          name: MermaidPad-${{ needs.get-version.outputs.version }}-osx-arm64.app
+          name: MermaidPad-${{ needs.get-version.outputs.version }}-osx-arm64.app.zip
           path: ./artifacts-app
 
       - name: Create or update tag for manual runs
@@ -216,7 +216,7 @@ jobs:
           name: MermaidPad v${{ needs.get-version.outputs.version }}
           artifacts: |
             ./artifacts/**/*.zip
-            ./artifacts-app/**/*.zip
+            ./artifacts-app/**/*.app.zip
           generateReleaseNotes: true
           allowUpdates: true
           prerelease: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.is_preview == 'true' }}

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -170,12 +170,3 @@ jobs:
         with:
           name: MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip
           path: MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip
-
-      # Upload the zipped .app bundle to the GitHub Release created by build-and-release.yml
-      - name: Upload .app bundle to the GitHub Release created by build-and-release.yml
-        uses: ncipollo/release-action@v1
-        with:
-          tag: v${{ inputs.version }}
-          artifacts: ./artifacts/MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app.zip
-          allowUpdates: true
-          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Remove extraneous ncipollo/release-action step done in macos-bundle.yml that was overwriting the one in build-and-release.yml. Update artifact handling for macOS bundles

Refactor `build-and-release.yml` to clarify artifact download comments and change artifact names to include `.zip` extension. Update paths to store downloaded artifacts in `./artifacts-app` and adjust release notes paths accordingly.

In `macos-bundle.yml`, remove the upload step to GitHub Release while retaining the upload action for the `.app` bundle zip artifact.