### PR TITLE
Remove redundant steps in GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -180,10 +180,11 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v4
 
-      - name: Download all build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: ./artifacts
+      # REMOVE DOWNLOAD REDUNDANCIES
+      # - name: Download all build artifacts
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     path: ./artifacts
 
       # Download macOS .app bundle zip (x64)
       - name: Download macOS .app bundle zip (x64)

--- a/.github/workflows/macos-bundle.yml
+++ b/.github/workflows/macos-bundle.yml
@@ -116,23 +116,24 @@ jobs:
       #
       #     echo "Success: Ad-hoc signing completed successfully!"
 
-      - name: List .app bundle contents
-        run: |
-          find ./artifacts/MermaidPad.app
+      # REMOVE REDUNDANCIES
+      # - name: List .app bundle contents
+      #   run: |
+      #     find ./artifacts/MermaidPad.app
 
-      # Upload the .app bundle immediately after creation
-      - name: Upload .app bundle artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app
-          path: ./artifacts/MermaidPad.app
+      # # Upload the .app bundle immediately after creation
+      # - name: Upload .app bundle artifact
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app
+      #     path: ./artifacts/MermaidPad.app
 
-      # Download the .app bundle artifact for zipping and release
-      - name: Download .app bundle artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app
-          path: ./artifacts
+      # # Download the .app bundle artifact for zipping and release
+      # - name: Download .app bundle artifact
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: MermaidPad-${{ inputs.version }}-${{ inputs.rid }}.app
+      #     path: ./artifacts
 
       # List contents of ./artifacts
       - name: List contents of ./artifacts


### PR DESCRIPTION
Remove redundant steps in GitHub Actions workflows

Commented out unnecessary steps in `build-and-release.yml` and `macos-bundle.yml` to streamline the workflow and improve efficiency.