### PR TITLE
Add version display and UI improvements #46

### DIFF
--- a/Assets/index.html
+++ b/Assets/index.html
@@ -22,7 +22,7 @@
     }
 
     body.dark-theme {
-      background: #1e1e1e;
+      background: #000;
       color: #ddd;
     }
 

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -25,6 +25,7 @@ using MermaidPad.Services;
 using Microsoft.Extensions.DependencyInjection;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 
 namespace MermaidPad.ViewModels;
 
@@ -64,6 +65,12 @@ public sealed partial class MainViewModel : ViewModelBase
     public partial string? LatestMermaidVersion { get; set; }
 
     /// <summary>
+    /// Gets or sets the current installed version of MermaidPad.
+    /// </summary>
+    [ObservableProperty]
+    public partial string? CurrentMermaidPadVersion { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether live preview is enabled.
     /// </summary>
     [ObservableProperty]
@@ -97,6 +104,8 @@ public sealed partial class MainViewModel : ViewModelBase
         _settingsService = services.GetRequiredService<SettingsService>();
         _updateService = services.GetRequiredService<MermaidUpdateService>();
         _editorDebouncer = services.GetRequiredService<IDebounceDispatcher>();
+
+        InitializeCurrentMermaidPadVersion();
 
         // Initialize properties from settings
         DiagramText = _settingsService.Settings.LastDiagramText ?? SampleText;
@@ -210,6 +219,24 @@ public sealed partial class MainViewModel : ViewModelBase
         await _updateService.CheckAndUpdateAsync();
         BundledMermaidVersion = _settingsService.Settings.BundledMermaidVersion;
         LatestMermaidVersion = _settingsService.Settings.LatestCheckedMermaidVersion;
+    }
+
+    private void InitializeCurrentMermaidPadVersion()
+    {
+        try
+        {
+            var version = Assembly.GetExecutingAssembly().GetName().Version;
+            if (version is not null)
+            {
+                // Display 3 version fields as Major.Minor.Build (e.g., 1.2.3)
+                CurrentMermaidPadVersion = version.ToString(3);
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to get current MermaidPad version: {ex}");
+            CurrentMermaidPadVersion = "Unknown";
+        }
     }
 
     /// <summary>

--- a/Views/MainWindow.axaml
+++ b/Views/MainWindow.axaml
@@ -41,12 +41,22 @@
         Content="Close" />
       <CheckBox
         Margin="12,0,0,0"
-        Content="Live Preview"
+        Content="Live Preview:"
+        FlowDirection="RightToLeft"
         IsChecked="{Binding LivePreviewEnabled}" />
-      <TextBlock Margin="20,0,4,0" Text="Bundled:" />
+      <!--<TextBlock Margin="20,0,4,0" Text="Bundled:" />
       <TextBlock Text="{Binding BundledMermaidVersion}" />
       <TextBlock Margin="12,0,4,0" Text="Latest:" />
-      <TextBlock Text="{Binding LatestMermaidVersion}" />
+      <TextBlock Text="{Binding LatestMermaidVersion}" />-->
+      <TextBlock
+        Margin="12,0,0,0"
+        HorizontalAlignment="Right"
+        VerticalAlignment="Center"
+        Text="Version:" />
+      <TextBlock
+        HorizontalAlignment="Right"
+        VerticalAlignment="Center"
+        Text="{Binding CurrentMermaidPadVersion}" />
     </StackPanel>
     <Grid ColumnDefinitions="*,4,*">
       <edit:TextEditor
@@ -54,6 +64,7 @@
         Grid.Column="0"
         FontFamily="Consolas"
         HorizontalScrollBarVisibility="Auto"
+        LineNumbersForeground="Lime"
         ShowLineNumbers="True"
         SyntaxHighlighting="Mermaid"
         VerticalScrollBarVisibility="Auto" />


### PR DESCRIPTION
Add version display and UI improvements #46

Introduced `CurrentMermaidPadVersion` property in `MainViewModel` to store and display the current app version. Added `InitializeCurrentMermaidPadVersion` method to retrieve the version using reflection, with error handling for robustness.

Updated `MainWindow.axaml` to display the app version in the UI, replacing the "Bundled" version text block. Adjusted the "Live Preview" checkbox label and added a `LineNumbersForeground` property to the `TextEditor` for better customization.

Refactored and commented out unused UI elements for clarity.