### PR TITLE
Update Node.js requirement and add ESLint dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "eslint": "^9.39.1",
         "eslint-plugin-html": "^8.1.3",
         "globals": "^16.5.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {


### PR DESCRIPTION
Update Node.js requirement and add ESLint dependencies

Added a Node.js version requirement (`>=18`) in the `engines`
field of `package-lock.json` to ensure compatibility. Updated
`devDependencies` to include `@eslint/js`, `eslint`,
`eslint-plugin-html`, and `globals` for improved linting and
code quality enforcement.