### PR TITLE
#186 - Add third-party libraries and support documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,7 +826,7 @@ Download the appropriate version for your processor:
 
 Download the appropriate version for your processor:
 - **x64 (64-bit Intel/AMD):** `MermaidPad-[version]-linux-x64.zip`
-- **arm64:** Not supported (CefGlue limitation – see [here](https://github.com/OutSystems/CefGlue/blob/main/LINUX.md#arm64-issues))
+- **arm64:** Not supported (CefGlue limitation - see [here](https://github.com/OutSystems/CefGlue/blob/main/LINUX.md#arm64-issues))
 
 **Installation:**
 1. Download and extract the appropriate .zip file
@@ -1015,12 +1015,14 @@ MermaidPad uses several open-source projects, including:
 
 - [Microsoft .NET](https://dot.net) - for the cross-platform application framework
 - [Avalonia UI](https://avaloniaui.net) - for cross-platform desktop UI
-- [MermaidJS](https://github.com/mermaid-js/mermaid) – for diagram rendering
-- [js-yaml](https://github.com/nodeca/js-yaml) – for YAML parsing
-- [panzoom](https://github.com/timmywil/panzoom) – for zoom and pan interactions
-- [@mermaid-js/layout-elk](https://github.com/mermaid-js/mermaid/tree/develop/packages/mermaid-layout-elk) – for ELK layout support
-- [TextMateSharp](https://github.com/danipen/TextMateSharp) - for syntax highlighting
-- [vscode-mermaid-syntax-highlight](https://github.com/bpruitt-goddard/vscode-mermaid-syntax-highlight) – for syntax highlighting
+- [MermaidJS](https://github.com/mermaid-js/mermaid) - for diagram rendering
+- [js-yaml](https://github.com/nodeca/js-yaml) - for YAML parsing
+- [panzoom](https://github.com/timmywil/panzoom) - for zoom and pan interactions
+- [@mermaid-js/layout-elk](https://github.com/mermaid-js/mermaid/tree/develop/packages/mermaid-layout-elk) - for ELK layout support
+- [TextMateSharp](https://github.com/danipen/TextMateSharp) - for syntax highlighting in AvaloniaUI
+- [vscode-mermaid-syntax-highlight](https://github.com/bpruitt-goddard/vscode-mermaid-syntax-highlight) - for Mermaid diagram syntax definition (imported for highlighting support)
+
+---
 
 ## Support
 

--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -1025,7 +1025,7 @@ runtimes\linux-arm64\native\libSkiaSharp.so
 runtimes\linux-musl-x64\native\libSkiaSharp.so
 runtimes\linux-x64\native\libSkiaSharp.so
 ----------------------------------------------
-Copyright (c) 2015-2016 Xamarin, Inc.  
+Copyright (c) 2015-2016 Xamarin, Inc.
 Copyright (c) 2017-2018 Microsoft Corporation.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -1033,4 +1033,3 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-


### PR DESCRIPTION
#186 - Add third-party libraries and support documentation

Added a "Third Party Libraries" section to the `README.md` to list
open-source dependencies with links and descriptions. Updated the
table of contents to include this section. Added a "Support" section
to the `README.md` with a donation link.

Introduced a `THIRD-PARTY-NOTICES.TXT` file to document third-party
libraries, their licenses, and copyright notices. Included runtime-
specific libraries and ensured compliance with open-source licensing
requirements.