### PR TITLE
Fix issue with intermittently not displaying FilePicker dialog

### DIFF
--- a/Infrastructure/ServiceConfiguration.cs
+++ b/Infrastructure/ServiceConfiguration.cs
@@ -79,7 +79,7 @@ public static class ServiceConfiguration
             // Create AssetService and extract assets asynchronously
             // Use Task.Run to explicitly offload file I/O to thread pool during app startup
             AssetService assetService = new AssetService(assetLogger, securityService, assetIntegrityService);
-            assetsDirectory = Task.Run(async () => await assetService.ExtractAssetsAsync())
+            assetsDirectory = Task.Run(() => assetService.ExtractAssetsAsync())
                 .GetAwaiter()
                 .GetResult();
 

--- a/Services/Export/ExportService.cs
+++ b/Services/Export/ExportService.cs
@@ -442,7 +442,7 @@ public sealed class ExportService
             // marshal only the UI-bound implementation to the UI thread.
             if (!Dispatcher.UIThread.CheckAccess())
             {
-                await Dispatcher.UIThread.InvokeAsync(async () => await ExportPngOnUiThreadAsync(targetPath, options, progress, cancellationToken));
+                await Dispatcher.UIThread.InvokeAsync(() => ExportPngOnUiThreadAsync(targetPath, options, progress, cancellationToken));
                 return;
             }
 
@@ -642,8 +642,7 @@ public sealed class ExportService
         else
         {
             // Not on UI thread - marshal to UI thread
-            result = await Dispatcher.UIThread.InvokeAsync(async () =>
-                await _mermaidRenderer.ExecuteScriptAsync(script));
+            result = await Dispatcher.UIThread.InvokeAsync(() => _mermaidRenderer.ExecuteScriptAsync(script));
         }
 
         if (string.IsNullOrWhiteSpace(result))

--- a/Services/MermaidRenderer.cs
+++ b/Services/MermaidRenderer.cs
@@ -628,7 +628,7 @@ public sealed class MermaidRenderer : IAsyncDisposable
 
                 // Explicit call (lambda still captures webView local, but the static local function prevents
                 // implicit capture of surrounding variables inside the function body).
-                await Dispatcher.UIThread.InvokeAsync(async () => await ClearOutputAsync(webView));
+                await Dispatcher.UIThread.InvokeAsync(() => ClearOutputAsync(webView));
 
                 _logger.LogDebug("Cleared output");
 
@@ -666,7 +666,7 @@ public sealed class MermaidRenderer : IAsyncDisposable
                 Debug.WriteLine($"Render result: {result ?? "null"}");
             }
 
-            await Dispatcher.UIThread.InvokeAsync(async () => await RenderMermaidAsync());
+            await Dispatcher.UIThread.InvokeAsync(RenderMermaidAsync);
         }
         catch (Exception ex)
         {
@@ -1089,7 +1089,7 @@ public sealed class MermaidRenderer : IAsyncDisposable
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogError(ex, "Failed to cancel export polling CTS");
+                        _logger.LogError(ex, "Failed to cancel export polling CancellationTokenSource");
                     }
                 }
 
@@ -1123,7 +1123,7 @@ public sealed class MermaidRenderer : IAsyncDisposable
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Failed to dispose export polling CTS");
+                    _logger.LogError(ex, "Failed to dispose export polling CancellationTokenSource");
                 }
             }
 

--- a/ViewModels/Dialogs/ExportDialogViewModel.cs
+++ b/ViewModels/Dialogs/ExportDialogViewModel.cs
@@ -287,13 +287,33 @@ public sealed partial class ExportDialogViewModel : ViewModelBase
     /// <param name="storageProvider">The storage provider used to display the folder picker dialog. Cannot be null.</param>
     /// <returns>A task that represents the asynchronous operation. The task completes when the directory selection process
     /// finishes.</returns>
-    /// <exception cref="ArgumentNullException">Thrown if the <paramref name="storageProvider"/> is null.</exception>
+    /// <remarks>
+    /// <para>
+    /// CRITICAL: Avalonia's IStorageProvider file/folder pickers require execution within a valid UI
+    /// SynchronizationContext. Even when code executes on the main thread, the absence of SynchronizationContext
+    /// causes pickers to silently fail or hang indefinitely without showing dialogs.
+    /// </para>
+    /// <para>
+    /// References:
+    /// - https://github.com/AvaloniaUI/Avalonia/discussions/13484
+    ///   (IStorageProvider.OpenFilePickerAsync randomly not showing the dialog)
+    /// - https://github.com/AvaloniaUI/Avalonia/discussions/15775
+    ///   (StorageProvider.OpenFolderPickerAsync blocks UI)
+    /// - https://github.com/AvaloniaUI/Avalonia/issues/15806
+    ///   (Async Main() causes picker failures - STA thread requirement)
+    /// </para>
+    /// <para>
+    /// Solution: Wrap all picker calls in Dispatcher.UIThread.InvokeAsync() to ensure proper context.
+    /// This is defensive programming against ConfigureAwait(false) in the call chain removing the context.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="storageProvider"/> is null.</exception>
     [RelayCommand]
     private Task BrowseForDirectoryAsync(IStorageProvider storageProvider)
     {
         ArgumentNullException.ThrowIfNull(storageProvider);
 
-        return BrowseForDirectoryCoreAsync(storageProvider);
+        return Dispatcher.UIThread.InvokeAsync(() => BrowseForDirectoryCoreAsync(storageProvider));
     }
 
     /// <summary>

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -221,13 +221,33 @@ public sealed partial class MainViewModel : ViewModelBase
     /// </summary>
     /// <param name="storageProvider">The storage provider used to select and access the file. Cannot be null.</param>
     /// <returns>A task that represents the asynchronous file open operation.</returns>
+    /// <remarks>
+    /// <para>
+    /// CRITICAL: Avalonia's IStorageProvider file/folder pickers require execution within a valid UI
+    /// SynchronizationContext. Even when code executes on the main thread, the absence of SynchronizationContext
+    /// causes pickers to silently fail or hang indefinitely without showing dialogs.
+    /// </para>
+    /// <para>
+    /// References:
+    /// - https://github.com/AvaloniaUI/Avalonia/discussions/13484
+    ///   (IStorageProvider.OpenFilePickerAsync randomly not showing the dialog)
+    /// - https://github.com/AvaloniaUI/Avalonia/discussions/15775
+    ///   (StorageProvider.OpenFolderPickerAsync blocks UI)
+    /// - https://github.com/AvaloniaUI/Avalonia/issues/15806
+    ///   (Async Main() causes picker failures - STA thread requirement)
+    /// </para>
+    /// <para>
+    /// Solution: Wrap all picker calls in Dispatcher.UIThread.InvokeAsync() to ensure proper context.
+    /// This is defensive programming against ConfigureAwait(false) in the call chain removing the context.
+    /// </para>
+    /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="storageProvider"/> is null.</exception>
     [RelayCommand]
     private Task OpenFileAsync(IStorageProvider storageProvider)
     {
         ArgumentNullException.ThrowIfNull(storageProvider);
 
-        return OpenFileCoreAsync(storageProvider);
+        return Dispatcher.UIThread.InvokeAsync(() => OpenFileCoreAsync(storageProvider));
     }
 
     /// <summary>
@@ -291,13 +311,33 @@ public sealed partial class MainViewModel : ViewModelBase
     /// </summary>
     /// <param name="storageProvider">The storage provider used to select the destination and perform the file save operation. Cannot be null.</param>
     /// <returns>A task that represents the asynchronous save operation.</returns>
+    /// <remarks>
+    /// <para>
+    /// CRITICAL: Avalonia's IStorageProvider file/folder pickers require execution within a valid UI
+    /// SynchronizationContext. Even when code executes on the main thread, the absence of SynchronizationContext
+    /// causes pickers to silently fail or hang indefinitely without showing dialogs.
+    /// </para>
+    /// <para>
+    /// References:
+    /// - https://github.com/AvaloniaUI/Avalonia/discussions/13484
+    ///   (IStorageProvider.OpenFilePickerAsync randomly not showing the dialog)
+    /// - https://github.com/AvaloniaUI/Avalonia/discussions/15775
+    ///   (StorageProvider.OpenFolderPickerAsync blocks UI)
+    /// - https://github.com/AvaloniaUI/Avalonia/issues/15806
+    ///   (Async Main() causes picker failures - STA thread requirement)
+    /// </para>
+    /// <para>
+    /// Solution: Wrap all picker calls in Dispatcher.UIThread.InvokeAsync() to ensure proper context.
+    /// This is defensive programming against ConfigureAwait(false) in the call chain removing the context.
+    /// </para>
+    /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="storageProvider"/> is null.</exception>
     [RelayCommand]
     private Task SaveFileAsync(IStorageProvider storageProvider)
     {
         ArgumentNullException.ThrowIfNull(storageProvider);
 
-        return SaveFileCoreAsync(storageProvider);
+        return Dispatcher.UIThread.InvokeAsync(() => SaveFileCoreAsync(storageProvider));
     }
 
     /// <summary>
@@ -334,13 +374,33 @@ public sealed partial class MainViewModel : ViewModelBase
     /// <param name="storageProvider">The storage provider used to present the file save dialog and handle file system access. Cannot be null.</param>
     /// <returns>A task that represents the asynchronous save operation. The task completes when the file has been saved or the
     /// operation is canceled.</returns>
+    /// <remarks>
+    /// <para>
+    /// CRITICAL: Avalonia's IStorageProvider file/folder pickers require execution within a valid UI
+    /// SynchronizationContext. Even when code executes on the main thread, the absence of SynchronizationContext
+    /// causes pickers to silently fail or hang indefinitely without showing dialogs.
+    /// </para>
+    /// <para>
+    /// References:
+    /// - https://github.com/AvaloniaUI/Avalonia/discussions/13484
+    ///   (IStorageProvider.OpenFilePickerAsync randomly not showing the dialog)
+    /// - https://github.com/AvaloniaUI/Avalonia/discussions/15775
+    ///   (StorageProvider.OpenFolderPickerAsync blocks UI)
+    /// - https://github.com/AvaloniaUI/Avalonia/issues/15806
+    ///   (Async Main() causes picker failures - STA thread requirement)
+    /// </para>
+    /// <para>
+    /// Solution: Wrap all picker calls in Dispatcher.UIThread.InvokeAsync() to ensure proper context.
+    /// This is defensive programming against ConfigureAwait(false) in the call chain removing the context.
+    /// </para>
+    /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="storageProvider"/> is null.</exception>
     [RelayCommand]
     private Task SaveFileAsAsync(IStorageProvider storageProvider)
     {
         ArgumentNullException.ThrowIfNull(storageProvider);
 
-        return SaveFileAsCoreAsync(storageProvider);
+        return Dispatcher.UIThread.InvokeAsync(() => SaveFileAsCoreAsync(storageProvider));
     }
 
     /// <summary>
@@ -395,7 +455,7 @@ public sealed partial class MainViewModel : ViewModelBase
             return Task.FromResult(true); // No unsaved changes, continue
         }
 
-        return PromptSaveIfDirtyCoreAsync(storageProvider);
+        return Dispatcher.UIThread.InvokeAsync(() => PromptSaveIfDirtyCoreAsync(storageProvider));
     }
 
     /// <summary>


### PR DESCRIPTION
Fix issue with intermittently not displaying FilePicker dialog. Avalonia's IStorageProvider file/folder pickers require execution within a valid UI SynchronizationContext. Even when code executes on the main thread, the absence of SynchronizationContext causes pickers to silently fail or hang indefinitely without showing dialogs.

Simplified `Dispatcher.UIThread.InvokeAsync` calls by removing
redundant `async`/`await` usage across multiple files, improving
code clarity and performance. Updated `ServiceConfiguration.cs`
to use `.GetAwaiter().GetResult()` for synchronous task handling.

Added critical remarks in `ExportDialogViewModel` and
`MainViewModel` to explain the importance of wrapping Avalonia's
`IStorageProvider` picker calls in `Dispatcher.UIThread.InvokeAsync`
to maintain a valid UI `SynchronizationContext`. Updated related
methods to ensure proper execution context and prevent silent
failures or hangs.