### PR TITLE
Add LogThreadContext method for detailed thread diagnostics

### DIFF
--- a/Extensions/LoggerExtensions.cs
+++ b/Extensions/LoggerExtensions.cs
@@ -75,8 +75,9 @@ public static class LoggerExtensions
             [Logical Context]
             SyncContext        : {ContextTypeName}
             HasDispatcherAccess: {HasDispatcherAccess}
+            Exception          : {Exception}
             -----------------------------------------
-            """, callerName, threadId, isBackground, isThreadPoolThread, thread.Name ?? "Unassigned", contextTypeName, hasDispatcherAccess);
+            """, callerName, threadId, isBackground, isThreadPoolThread, thread.Name ?? "Unassigned", contextTypeName, hasDispatcherAccess, exception);
     }
 
     /// <summary>


### PR DESCRIPTION
Add LogThreadContext method for detailed thread diagnostics

A new `LogThreadContext` extension method was added to the `LoggerExtensions` class in the `MermaidPad.Extensions` namespace. This method logs detailed diagnostic information about the current thread, synchronization context, and Avalonia dispatcher access.

Key features:
- Logs thread ID, background status, thread name, sync context, and dispatcher access status.
- Supports optional exception logging and uses `[CallerMemberName]` for traceability.
- Logs at the debug level with a structured format.

The `using Avalonia.Threading;` directive was added to enable dispatcher-related functionality. This addition is intended for
debugging and diagnostic purposes.