### PR TITLE
Refactor MainViewModel to MainWindowViewModel

### DIFF
--- a/Infrastructure/ServiceConfiguration.cs
+++ b/Infrastructure/ServiceConfiguration.cs
@@ -104,7 +104,7 @@ public static class ServiceConfiguration
         services.AddSingleton<IFileService, FileService>();
 
         // Main ViewModel: transient (one per window)
-        services.AddTransient<MainViewModel>();
+        services.AddTransient<MainWindowViewModel>();
 
         // Dialog ViewModels: transient (one per dialog instance)
         services.AddTransient<ExportDialogViewModel>();

--- a/ViewModels/Dialogs/ProgressDialogViewModel.cs
+++ b/ViewModels/Dialogs/ProgressDialogViewModel.cs
@@ -109,12 +109,12 @@ public sealed partial class ProgressDialogViewModel : ViewModelBase, IProgress<E
     /// </summary>
     /// <remarks>This method sets the <see cref="CloseRequested"/> property to <see langword="true"/>,
     /// indicating that the user has requested to close the dialog. The actual closing of the window is managed
-    /// externally, typically by a handler in the <c>MainViewModel</c>.</remarks>
+    /// externally, typically by a handler in the <see cref="MainWindowViewModel"/>.</remarks>
     [RelayCommand]
     private void Close()
     {
         // Signal that the user clicked the Close button and wants to dismiss the dialog
-        // The actual window closing is handled by MainViewModel's PropertyChanged handler
+        // The actual window closing is handled by MainWindowViewModel's PropertyChanged handler
         CloseRequested = true;
     }
 

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -41,13 +41,19 @@ using System.Text;
 namespace MermaidPad.ViewModels;
 
 /// <summary>
-/// Main window state container with commands and (optional) live preview.
+/// Represents the main view model for the application's main window, providing properties, commands, and logic for
+/// editing, rendering, exporting, and managing Mermaid diagrams.
 /// </summary>
+/// <remarks>This view model exposes state and command properties for data binding in the main window, including
+/// file operations, diagram rendering, clipboard actions, and export functionality. It coordinates interactions between
+/// the user interface and underlying services such as file management, rendering, and settings persistence. All
+/// properties and commands are designed for use with MVVM frameworks and are intended to be accessed by the view for UI
+/// updates and user interactions.</remarks>
 [SuppressMessage("ReSharper", "MemberCanBeMadeStatic.Global", Justification = "ViewModel properties are instance-based for binding.")]
 [SuppressMessage("ReSharper", "PropertyCanBeMadeInitOnly.Global", Justification = "ViewModel properties are set during initialization by the MVVM framework.")]
 [SuppressMessage("ReSharper", "MemberCanBePrivate.Global", Justification = "ViewModel properties are accessed by the view for data binding.")]
 [SuppressMessage("ReSharper", "UnusedMember.Global", Justification = "ViewModel members are accessed by the view for data binding.")]
-public sealed partial class MainViewModel : ViewModelBase
+public sealed partial class MainWindowViewModel : ViewModelBase
 {
     private readonly MermaidRenderer _renderer;
     private readonly SettingsService _settingsService;
@@ -56,7 +62,7 @@ public sealed partial class MainViewModel : ViewModelBase
     private readonly ExportService _exportService;
     private readonly IDialogFactory _dialogFactory;
     private readonly IFileService _fileService;
-    private readonly ILogger<MainViewModel> _logger;
+    private readonly ILogger<MainWindowViewModel> _logger;
 
     private const string DebounceRenderKey = "render";
 
@@ -183,11 +189,11 @@ public sealed partial class MainViewModel : ViewModelBase
     public bool HasRecentFiles => RecentFiles.Count > 0;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="MainViewModel"/> class.
+    /// Initializes a new instance of the <see cref="MainWindowViewModel"/> class.
     /// </summary>
     /// <param name="services">The service provider for dependency injection.</param>
     /// <param name="logger">The logger instance for this view model.</param>
-    public MainViewModel(IServiceProvider services, ILogger<MainViewModel> logger)
+    public MainWindowViewModel(IServiceProvider services, ILogger<MainWindowViewModel> logger)
     {
         _renderer = services.GetRequiredService<MermaidRenderer>();
         _settingsService = services.GetRequiredService<SettingsService>();

--- a/Views/MainWindow.axaml
+++ b/Views/MainWindow.axaml
@@ -9,7 +9,7 @@
   Title="{Binding WindowTitle}"
   Width="1200"
   Height="800"
-  x:DataType="vm:MainViewModel"
+  x:DataType="vm:MainWindowViewModel"
   Icon="/Assets/AppIcon.ico">
 
   <Window.Resources>
@@ -52,7 +52,7 @@
           <MenuItem.ItemTemplate>
             <DataTemplate x:DataType="x:String">
               <MenuItem Header="{Binding}"
-                        Command="{ReflectionBinding $parent[TopLevel].DataContext.(vm:MainViewModel.OpenRecentFileCommand), FallbackValue={x:Null}}"
+                        Command="{ReflectionBinding $parent[TopLevel].DataContext.(vm:MainWindowViewModel.OpenRecentFileCommand), FallbackValue={x:Null}}"
                         CommandParameter="{Binding}" />
             </DataTemplate>
           </MenuItem.ItemTemplate>

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -39,12 +39,12 @@ namespace MermaidPad.Views;
 
 /// <summary>
 /// Main application window that contains the editor and preview WebView.
-/// Manages synchronization between the editor control and the <see cref="MainViewModel"/>,
+/// Manages synchronization between the editor control and the <see cref="MainWindowViewModel"/>,
 /// initializes and manages the <see cref="MermaidRenderer"/>, and handles window lifecycle events.
 /// </summary>
 public sealed partial class MainWindow : Window
 {
-    private readonly MainViewModel _vm;
+    private readonly MainWindowViewModel _vm;
     private readonly MermaidRenderer _renderer;
     private readonly MermaidUpdateService _updateService;
     private readonly SyntaxHighlightingService _syntaxHighlightingService;
@@ -82,7 +82,7 @@ public sealed partial class MainWindow : Window
         IServiceProvider sp = App.Services;
         _editorDebouncer = sp.GetRequiredService<IDebounceDispatcher>();
         _renderer = sp.GetRequiredService<MermaidRenderer>();
-        _vm = sp.GetRequiredService<MainViewModel>();
+        _vm = sp.GetRequiredService<MainWindowViewModel>();
         _updateService = sp.GetRequiredService<MermaidUpdateService>();
         _syntaxHighlightingService = sp.GetRequiredService<SyntaxHighlightingService>();
         _logger = sp.GetRequiredService<ILogger<MainWindow>>();
@@ -419,7 +419,7 @@ public sealed partial class MainWindow : Window
     /// <returns>A task representing the asynchronous open sequence.</returns>
     /// <exception cref="InvalidOperationException">Thrown if required update assets cannot be resolved.</exception>
     /// <remarks>
-    /// This method logs timing information, performs an update check by calling <see cref="MainViewModel.CheckForMermaidUpdatesAsync"/>,
+    /// This method logs timing information, performs an update check by calling <see cref="MainWindowViewModel.CheckForMermaidUpdatesAsync"/>,
     /// initializes the renderer via <see cref="InitializeWebViewAsync"/>, and notifies commands to refresh their CanExecute state.
     /// Exceptions are propagated for higher-level handling.
     /// </remarks>
@@ -783,7 +783,7 @@ public sealed partial class MainWindow : Window
     /// safety.</remarks>
     /// <returns>
     /// A <see cref="Task"/> that represents the asynchronous operation of updating the ViewModel's
-    /// <see cref="MainViewModel.CanPasteClipboard"/> property based on the current clipboard contents.
+    /// <see cref="MainWindowViewModel.CanPasteClipboard"/> property based on the current clipboard contents.
     /// The task completes when the property has been updated.
     /// </returns>
     private async Task UpdateCanPasteClipboardAsync()


### PR DESCRIPTION
Refactor MainViewModel to MainWindowViewModel

Renamed `MainViewModel` to `MainWindowViewModel` across the codebase to better reflect its role as the view model for the main application window. Updated all references, including class declarations, constructors, service registrations, data bindings, and logger fields.

Revised comments and XML documentation to ensure consistency and accuracy. Enhanced the documentation for `MainWindowViewModel` to provide a detailed description of its responsibilities.

Updated XAML bindings in `MainWindow.axaml` to align with the renamed view model. Adjusted dependency injection and initialization logic in `MainWindow.axaml.cs` to use `MainWindowViewModel`.

Ensured consistency across all files to improve code clarity, maintainability, and adherence to the MVVM design pattern.