### PR TITLE
Add CanSelectAll protection around SelectAll feature

### DIFF
--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -163,6 +163,12 @@ public sealed partial class MainWindowViewModel : ViewModelBase
     [ObservableProperty]
     public partial bool CanRedo { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the 'Select All' operation is available.
+    /// </summary>
+    [ObservableProperty]
+    public partial bool CanSelectAll { get; set; }
+
     #endregion Clipboard and Edit Properties
 
     #region Clipboard and Edit Actions
@@ -1202,7 +1208,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase
     /// <summary>
     /// Selects all text in the editor.
     /// </summary>
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanSelectAll))]
     private void SelectAll() => SelectAllAction?.Invoke();
 
     /// <summary>

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -182,10 +182,12 @@ public sealed partial class MainWindow : Window
             // Update undo/redo states immediately (not debounced)
             _vm.CanUndo = Editor.CanUndo;
             _vm.CanRedo = Editor.CanRedo;
+            _vm.CanSelectAll = CanSelectAll;
 
             // Notify commands that their CanExecute state may have changed
             _vm.UndoCommand.NotifyCanExecuteChanged();
             _vm.RedoCommand.NotifyCanExecuteChanged();
+            _vm.SelectAllCommand.NotifyCanExecuteChanged();
 
             // Debounce to avoid excessive updates
             _editorDebouncer.DebounceOnUI("editor-text", TimeSpan.FromMilliseconds(DebounceDispatcher.DefaultTextDebounceMilliseconds), () =>
@@ -327,7 +329,7 @@ public sealed partial class MainWindow : Window
                     try
                     {
                         // Validate bounds before setting
-                        int textLength = Editor.Text.Length;
+                        int textLength = Editor.Document.TextLength;
                         int validSelectionStart = Math.Max(0, Math.Min(_vm.EditorSelectionStart, textLength));
                         int validSelectionLength = Math.Max(0, Math.Min(_vm.EditorSelectionLength, textLength - validSelectionStart));
                         int validCaretOffset = Math.Max(0, Math.Min(_vm.EditorCaretOffset, textLength));
@@ -1125,6 +1127,11 @@ public sealed partial class MainWindow : Window
     }
 
     /// <summary>
+    /// Gets a value indicating whether the Select All operation can be performed in the editor.
+    /// </summary>
+    private bool CanSelectAll => Editor?.Document?.TextLength > 0;
+
+    /// <summary>
     /// Opens the find panel in the editor.
     /// </summary>
     /// <remarks>
@@ -1262,6 +1269,7 @@ public sealed partial class MainWindow : Window
                 _vm.CanCutClipboard = _vm.EditorSelectionLength > 0;
                 _vm.CanUndo = Editor.CanUndo;
                 _vm.CanRedo = Editor.CanRedo;
+                _vm.CanSelectAll = CanSelectAll;
             }
             else
             {
@@ -1271,6 +1279,7 @@ public sealed partial class MainWindow : Window
                     _vm.CanCutClipboard = _vm.EditorSelectionLength > 0;
                     _vm.CanUndo = Editor.CanUndo;
                     _vm.CanRedo = Editor.CanRedo;
+                    _vm.CanSelectAll = CanSelectAll;
                 }, DispatcherPriority.Normal);
             }
 


### PR DESCRIPTION
#### PR Classification
New feature and code robustness improvements.

#### PR Summary
This pull request adds support for the 'Select All' operation in the editor and improves the robustness of HTTP listener disposal in `MermaidRenderer`. It also enhances logging and state synchronization for better maintainability and user experience.
- **MermaidRenderer.cs**: Improved HTTP listener disposal with exception handling and ensured `_serverReadySemaphore` is always disposed.
- **MainWindowViewModel.cs**: Added `CanSelectAll` property and updated `SelectAll` command with `CanExecute` logic.
- **MainWindow.axaml.cs**: Integrated `CanSelectAll` updates into editor state synchronization and replaced `Editor.Text.Length` with `Editor.Document.TextLength` for better performance.
