### PR TITLE
#162, #231 Add ShowCancelButton to dialogs, confirm before clearing, add undo to Clear All

### DIFF
--- a/ViewModels/Dialogs/ConfirmationDialogViewModel.cs
+++ b/ViewModels/Dialogs/ConfirmationDialogViewModel.cs
@@ -65,6 +65,11 @@ public sealed class ConfirmationDialogViewModel : ViewModelBase
     /// Gets or sets the text for the Cancel button.
     /// </summary>
     public string CancelButtonText { get; set; } = "_Cancel";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the Cancel button is visible in the user interface.
+    /// </summary>
+    public bool ShowCancelButton { get; set; }
 }
 
 /// <summary>

--- a/ViewModels/Dialogs/ExportDialogViewModel.cs
+++ b/ViewModels/Dialogs/ExportDialogViewModel.cs
@@ -488,8 +488,8 @@ public sealed partial class ExportDialogViewModel : ViewModelBase
 
                 // Create confirmation window
                 ConfirmationDialogViewModel confirmViewModel = _dialogFactory.CreateViewModel<ConfirmationDialogViewModel>();
+                confirmViewModel.ShowCancelButton = true;
                 confirmViewModel.Title = "Confirm Overwrite";
-
                 confirmViewModel.Message = $"The file already exists:{Environment.NewLine}{Environment.NewLine}{Path.GetFullPath(filePath)}{Environment.NewLine}{Environment.NewLine}Do you want to overwrite it?";
                 confirmViewModel.IconData = "M12,2C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22C17.52,22 22,17.52 22,12C22,6.48 17.52,2 12,2M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M11,7V13H13V7H11M11,15V17H13V15H11Z"; // Warning icon
                 confirmViewModel.IconColor = Avalonia.Media.Brushes.Orange;

--- a/ViewModels/SplashWindowViewModel.cs
+++ b/ViewModels/SplashWindowViewModel.cs
@@ -1,4 +1,4 @@
-﻿// MIT License
+// MIT License
 // Copyright (c) 2025 Dave Black
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,6 +20,4 @@
 
 namespace MermaidPad.ViewModels;
 
-public sealed partial class SplashWindowViewModel : ViewModelBase
-{
-}
+public sealed partial class SplashWindowViewModel : ViewModelBase;

--- a/Views/Dialogs/ConfirmationDialog.axaml
+++ b/Views/Dialogs/ConfirmationDialog.axaml
@@ -39,7 +39,8 @@
         Click="OnCancelClick"
         Content="{Binding CancelButtonText}"
         HotKey="Alt+C"
-        IsCancel="True" />
+        IsCancel="True"
+        IsVisible="{Binding ShowCancelButton}" />
     </StackPanel>
 
     <Grid>


### PR DESCRIPTION
#### PR Classification
New feature and UI enhancement for confirmation dialogs and editor clearing workflow. Add Undo to Clear All action.

Resolves #162, #231 

#### PR Summary
This PR adds configurable Cancel button visibility to confirmation dialogs and introduces a confirmation step before clearing the editor, improving user experience and undo support.
- ConfirmationDialogViewModel.cs: Adds ShowCancelButton property to control Cancel button visibility.
- ConfirmationDialog.axaml: Binds Cancel button visibility to ShowCancelButton.
- MainWindowViewModel.cs: Implements ClearAsync command with confirmation dialog (optionally hiding Cancel), and refactors clearing logic to ClearCoreAsync for proper undo support.
- ExportDialogViewModel.cs: Ensures Cancel button is visible in overwrite confirmation dialogs.
- SplashWindowViewModel.cs: Minor formatting and class declaration fix.
