### PR TITLE
#296 - Refactor WebView into User Control

### DIFF
--- a/MermaidPad.csproj
+++ b/MermaidPad.csproj
@@ -1,201 +1,209 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>WinExe</OutputType>
-		<Nullable>enable</Nullable>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<RootNamespace>MermaidPad</RootNamespace>
-		<AssemblyName>MermaidPad</AssemblyName>
-		<UseAvalonia>true</UseAvalonia>
-		<ApplicationIcon>Assets/AppIcon.ico</ApplicationIcon>
-		<AssemblyTitle>MermaidPad</AssemblyTitle>
-		<AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-		<EnableDefaultItems>true</EnableDefaultItems>
-		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-		<LangVersion>preview</LangVersion>
-		<Configurations>Debug;Release;</Configurations>
-	</PropertyGroup>
+    <PropertyGroup>
+        <OutputType>WinExe</OutputType>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <RootNamespace>MermaidPad</RootNamespace>
+        <AssemblyName>MermaidPad</AssemblyName>
+        <UseAvalonia>true</UseAvalonia>
+        <ApplicationIcon>Assets/AppIcon.ico</ApplicationIcon>
+        <AssemblyTitle>MermaidPad</AssemblyTitle>
+        <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+        <EnableDefaultItems>true</EnableDefaultItems>
+        <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+        <LangVersion>preview</LangVersion>
+        <Configurations>Debug;Release;</Configurations>
+    </PropertyGroup>
 
-	<PropertyGroup Label="Avalonia">
-		<AvaloniaXamlVerboseExceptions>True</AvaloniaXamlVerboseExceptions>
-		<!--<AvaloniaXamlIlDebuggerLaunch>True</AvaloniaXamlIlDebuggerLaunch>-->
-		<AvaloniaXamlReportImportance>Normal</AvaloniaXamlReportImportance>
-	</PropertyGroup>
+    <PropertyGroup Label="Avalonia">
+        <AvaloniaXamlVerboseExceptions>True</AvaloniaXamlVerboseExceptions>
+        <!--<AvaloniaXamlIlDebuggerLaunch>True</AvaloniaXamlIlDebuggerLaunch>-->
+        <AvaloniaXamlReportImportance>Normal</AvaloniaXamlReportImportance>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="AsyncAwaitBestPractices" Version="9.0.0" />
-		<PackageReference Include="AsyncAwaitBestPractices.MVVM" Version="9.0.0" />
-		<PackageReference Include="Avalonia" Version="11.3.10" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.3.10" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.10" />
-		<PackageReference Include="AvaloniaEdit.TextMate" Version="11.3.0" />
-		<PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
-		<!--<PackageReference Include="MessageBox.Avalonia" Version="3.2.0" />-->
-		<PackageReference Include="Microsoft.DotNet.ApiCompat.Task" Version="9.0.308" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="9.0.11" />
-		<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Serilog" Version="4.3.0" />
-		<PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
-		<PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />
-		<PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
-		<PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
-		<PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-		<PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
-		<PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
-		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-		<PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
-		<PackageReference Include="SkiaSharp" Version="3.119.1" />
-		<PackageReference Include="Svg.Skia" Version="3.2.1" />
-		<PackageReference Include="TextMateSharp" Version="1.0.70" />
-		<PackageReference Include="TextMateSharp.Grammars" Version="1.0.70" />
-		<PackageReference Include="WebView.Avalonia" Version="11.0.0.1" />
-		<PackageReference Include="Avalonia.AvaloniaEdit" Version="11.3.0" />
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.11" />
-		<PackageReference Include="WebView.Avalonia.Desktop" Version="11.0.0.1" />
-		<PackageReference Include="WebView.Avalonia.Linux" Version="11.0.0.1" />
-		<PackageReference Include="WebView.Avalonia.MacCatalyst" Version="11.0.0.1" />
-		<PackageReference Include="WebView.Avalonia.Windows" Version="11.0.0.1" />
-	</ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="AsyncAwaitBestPractices" Version="9.0.0" />
+        <PackageReference Include="AsyncAwaitBestPractices.MVVM" Version="9.0.0" />
+        <PackageReference Include="Avalonia" Version="11.3.10" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.3.10" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.10" />
+        <PackageReference Include="AvaloniaEdit.TextMate" Version="11.3.0" />
+        <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
+        <!--<PackageReference Include="MessageBox.Avalonia" Version="3.2.0" />-->
+        <PackageReference Include="Microsoft.DotNet.ApiCompat.Task" Version="9.0.308" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.11" />
+        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="9.0.11" />
+        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Serilog" Version="4.3.0" />
+        <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
+        <PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />
+        <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
+        <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
+        <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
+        <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
+        <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
+        <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+        <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
+        <PackageReference Include="SkiaSharp" Version="3.119.1" />
+        <PackageReference Include="Svg.Skia" Version="3.2.1" />
+        <PackageReference Include="TextMateSharp" Version="1.0.70" />
+        <PackageReference Include="TextMateSharp.Grammars" Version="1.0.70" />
+        <PackageReference Include="WebView.Avalonia" Version="11.0.0.1" />
+        <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.3.0" />
+        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.11" />
+        <PackageReference Include="WebView.Avalonia.Desktop" Version="11.0.0.1" />
+        <PackageReference Include="WebView.Avalonia.Linux" Version="11.0.0.1" />
+        <PackageReference Include="WebView.Avalonia.MacCatalyst" Version="11.0.0.1" />
+        <PackageReference Include="WebView.Avalonia.Windows" Version="11.0.0.1" />
+    </ItemGroup>
 
-	<!-- Only include Avalonia.Diagnostics in Debug builds -->
-	<ItemGroup Condition="'$(Configuration)' == 'Debug'">
-		<PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.1.1" />
-	</ItemGroup>
+    <!-- Only include Avalonia.Diagnostics in Debug builds -->
+    <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+        <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.1.1" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<!-- https://github.com/AvaloniaUI/Avalonia/issues/5877#issuecomment-833426154 -->
-		<!--        This line important -->
-		<AvaloniaXaml Remove="**/*.axaml" />
-		<AvaloniaXaml Remove="node_modules/**" />
-		<Compile Remove="node_modules/**" />
-		<EmbeddedResource Remove="node_modules/**" />
-		<None Remove="node_modules/**" />
-		<!--        This line important -->
-	</ItemGroup>
-	<ItemGroup>
-		<AvaloniaResource Include="Assets/AppIcon.ico" />
-		<AvaloniaResource Include="Assets/SplashScreen.png" />
-		<AdditionalFiles Include="**/*.xaml" />
-		<AdditionalFiles Include="**/*.axaml" />
-	</ItemGroup>
-	<ItemGroup>
-		<EmbeddedResource Include="Assets/index.html">
-			<LogicalName>MermaidPad.Assets.index.html</LogicalName>
-		</EmbeddedResource>
-		<EmbeddedResource Include="Assets/mermaid.min.js">
-			<LogicalName>MermaidPad.Assets.mermaid.min.js</LogicalName>
-		</EmbeddedResource>
-		<EmbeddedResource Include="Assets/js-yaml.min.js">
-			<LogicalName>MermaidPad.Assets.js-yaml.min.js</LogicalName>
-		</EmbeddedResource>
-		<EmbeddedResource Include="Assets/mermaid-elk-layout/mermaid-layout-elk.esm.min.mjs">
-			<LogicalName>MermaidPad.Assets.mermaid-elk-layout.mermaid-layout-elk.esm.min.mjs</LogicalName>
-		</EmbeddedResource>
-		<EmbeddedResource Include="Assets/mermaid-elk-layout/chunks/mermaid-layout-elk.esm.min/chunk-SP2CHFBE.mjs">
-			<LogicalName>MermaidPad.Assets.mermaid-elk-layout.chunks.mermaid-layout-elk.esm.min.chunk-SP2CHFBE.mjs</LogicalName>
-		</EmbeddedResource>
-		<EmbeddedResource Include="Assets/mermaid-elk-layout/chunks/mermaid-layout-elk.esm.min/render-AVRWSH4D.mjs">
-			<LogicalName>MermaidPad.Assets.mermaid-elk-layout.chunks.mermaid-layout-elk.esm.min.render-AVRWSH4D.mjs</LogicalName>
-		</EmbeddedResource>
-		<EmbeddedResource Include="Resources/Grammars/mermaid.tmLanguage.json">
-			<LogicalName>MermaidPad.Resources.Grammars.mermaid.tmLanguage.json</LogicalName>
-		</EmbeddedResource>
-	</ItemGroup>
+    <ItemGroup>
+        <!-- https://github.com/AvaloniaUI/Avalonia/issues/5877#issuecomment-833426154 -->
+        <!--        This line important -->
+        <AvaloniaXaml Remove="**/*.axaml" />
+        <AvaloniaXaml Remove="node_modules/**" />
+        <Compile Remove="node_modules/**" />
+        <EmbeddedResource Remove="node_modules/**" />
+        <None Remove="node_modules/**" />
+        <!--        This line important -->
+    </ItemGroup>
+    <ItemGroup>
+        <AvaloniaResource Include="Assets/AppIcon.ico" />
+        <AvaloniaResource Include="Assets/SplashScreen.png" />
+        <AdditionalFiles Include="**/*.xaml" />
+        <AdditionalFiles Include="**/*.axaml" />
+    </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="Assets/index.html">
+            <LogicalName>MermaidPad.Assets.index.html</LogicalName>
+        </EmbeddedResource>
+        <EmbeddedResource Include="Assets/mermaid.min.js">
+            <LogicalName>MermaidPad.Assets.mermaid.min.js</LogicalName>
+        </EmbeddedResource>
+        <EmbeddedResource Include="Assets/js-yaml.min.js">
+            <LogicalName>MermaidPad.Assets.js-yaml.min.js</LogicalName>
+        </EmbeddedResource>
+        <EmbeddedResource Include="Assets/mermaid-elk-layout/mermaid-layout-elk.esm.min.mjs">
+            <LogicalName>MermaidPad.Assets.mermaid-elk-layout.mermaid-layout-elk.esm.min.mjs</LogicalName>
+        </EmbeddedResource>
+        <EmbeddedResource Include="Assets/mermaid-elk-layout/chunks/mermaid-layout-elk.esm.min/chunk-SP2CHFBE.mjs">
+            <LogicalName>MermaidPad.Assets.mermaid-elk-layout.chunks.mermaid-layout-elk.esm.min.chunk-SP2CHFBE.mjs</LogicalName>
+        </EmbeddedResource>
+        <EmbeddedResource Include="Assets/mermaid-elk-layout/chunks/mermaid-layout-elk.esm.min/render-AVRWSH4D.mjs">
+            <LogicalName>MermaidPad.Assets.mermaid-elk-layout.chunks.mermaid-layout-elk.esm.min.render-AVRWSH4D.mjs</LogicalName>
+        </EmbeddedResource>
+        <EmbeddedResource Include="Resources/Grammars/mermaid.tmLanguage.json">
+            <LogicalName>MermaidPad.Resources.Grammars.mermaid.tmLanguage.json</LogicalName>
+        </EmbeddedResource>
+    </ItemGroup>
 
-	<ItemGroup>
-		<Compile Update="**/*.xaml.cs">
-			<DependentUpon>%(Filename)</DependentUpon>
-		</Compile>
-		<Compile Update="**/*.axaml.cs">
-			<DependentUpon>%(Filename)</DependentUpon>
-		</Compile>
-		<AvaloniaResource Include="**/*.xaml">
-			<SubType>Designer</SubType>
-		</AvaloniaResource>
-		<AvaloniaResource Include="**/*.axaml">
-			<SubType>Designer</SubType>
-		</AvaloniaResource>
-	</ItemGroup>
+    <ItemGroup>
+        <Compile Update="**/*.xaml.cs">
+            <DependentUpon>%(Filename)</DependentUpon>
+        </Compile>
+        <Compile Update="**/*.axaml.cs">
+            <DependentUpon>%(Filename)</DependentUpon>
+        </Compile>
+        <AvaloniaResource Include="**/*.xaml">
+            <SubType>Designer</SubType>
+        </AvaloniaResource>
+        <AvaloniaResource Include="**/*.axaml">
+            <SubType>Designer</SubType>
+        </AvaloniaResource>
+    </ItemGroup>
 
-	<ItemGroup>
-		<AdditionalFiles Remove="node_modules/**" />
-		<AvaloniaResource Remove="**/*.axaml" />
-		<AvaloniaResource Remove="node_modules/**" />
-	</ItemGroup>
+    <ItemGroup>
+        <AdditionalFiles Remove="node_modules/**" />
+        <AvaloniaResource Remove="**/*.axaml" />
+        <AvaloniaResource Remove="node_modules/**" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<AvaloniaXaml Include="**/*.axaml" />
-	</ItemGroup>
+    <ItemGroup>
+        <AvaloniaXaml Include="**/*.axaml" />
+    </ItemGroup>
 
-	<ItemGroup>
-	  <AdditionalFiles Remove="Dialogs/MessageDialog.axaml" />
-	  <AdditionalFiles Remove="Dialogs/ExportDialog.axaml" />
-	  <AdditionalFiles Remove="Views/Dialogs/ProgressDialog.axaml" />
-	  <AdditionalFiles Remove="Views/Dialogs/ConfirmationDialog.axaml" />
-	  <AdditionalFiles Remove="Views/SplashWindow.axaml" />
-	</ItemGroup>
+    <ItemGroup>
+        <AdditionalFiles Remove="Dialogs/MessageDialog.axaml" />
+        <AdditionalFiles Remove="Dialogs/ExportDialog.axaml" />
+        <AdditionalFiles Remove="Views/Dialogs/ProgressDialog.axaml" />
+        <AdditionalFiles Remove="Views/Dialogs/ConfirmationDialog.axaml" />
+        <AdditionalFiles Remove="Views/UserControls/DiagramView.axaml" />
+        <AdditionalFiles Remove="Views/UserControls/MermaidEditorView.axaml" />
+        <AdditionalFiles Remove="Views/SplashWindow.axaml" />
+    </ItemGroup>
 
-	<ItemGroup>
-	  <None Remove="Assets/SplashScreen.png" />
-	  <None Remove="Resources/Grammars/mermaid.tmLanguage.json" />
-	</ItemGroup>
+    <ItemGroup>
+        <None Remove="Assets/SplashScreen.png" />
+        <None Remove="Resources/Grammars/mermaid.tmLanguage.json" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<None Include=".github/workflows/build-and-release.yml" />
-		<None Include=".github/workflows/codeql.yml" />
-		<None Include=".github/workflows/enforce-pr-targets.yml" />
-		<None Include=".github/workflows/first-interaction.yml" />
-		<None Include=".github/workflows/macos-universal-dmg.yml" />
-		<None Include=".github/workflows/macos-bundle.yml" />
-		<None Include=".github/workflows/README.md" />
+    <ItemGroup>
+        <None Include=".github/workflows/build-and-release.yml" />
+        <None Include=".github/workflows/codeql.yml" />
+        <None Include=".github/workflows/enforce-pr-targets.yml" />
+        <None Include=".github/workflows/first-interaction.yml" />
+        <None Include=".github/workflows/macos-universal-dmg.yml" />
+        <None Include=".github/workflows/macos-bundle.yml" />
+        <None Include=".github/workflows/README.md" />
         <None Include=".github/pull_request_template.md" />
         <None Include=".github/ISSUE_TEMPLATE/config.yml" />
-		<None Include=".github/ISSUE_TEMPLATE/feature-request.yml" />
-		<None Include=".github/ISSUE_TEMPLATE/bug-report.yml" />
-	</ItemGroup>
+        <None Include=".github/ISSUE_TEMPLATE/feature-request.yml" />
+        <None Include=".github/ISSUE_TEMPLATE/bug-report.yml" />
+    </ItemGroup>
 
-	<!-- macOS app bundle support -->
-	<ItemGroup Condition="'$(RuntimeIdentifier)' == 'osx-x64' Or '$(RuntimeIdentifier)' == 'osx-arm64'">
-		<None Include="Info.plist" CopyToOutputDirectory="PreserveNewest" />
-		<None Include="Assets/AppIcon.icns" CopyToOutputDirectory="PreserveNewest" />
-	</ItemGroup>
-	<ItemGroup>
-	  <AvaloniaXaml Update="Views/Dialogs/MessageDialog.axaml">
-	    <SubType>Designer</SubType>
-	  </AvaloniaXaml>
-	  <AvaloniaXaml Update="Views/Dialogs/ExportDialog.axaml">
-	    <SubType>Designer</SubType>
-	  </AvaloniaXaml>
-	  <AvaloniaXaml Update="Views/Dialogs/ProgressDialog.axaml">
-	    <SubType>Designer</SubType>
-	  </AvaloniaXaml>
-		<AvaloniaXaml Update="Views/Dialogs/ConfirmationDialog.axaml">
-			<SubType>Designer</SubType>
-		</AvaloniaXaml>
-		<AvaloniaXaml Update="Views/SplashWindow.axaml">
-			<SubType>Designer</SubType>
-		</AvaloniaXaml>
-	</ItemGroup>
+    <!-- macOS app bundle support -->
+    <ItemGroup Condition="'$(RuntimeIdentifier)' == 'osx-x64' Or '$(RuntimeIdentifier)' == 'osx-arm64'">
+        <None Include="Info.plist" CopyToOutputDirectory="PreserveNewest" />
+        <None Include="Assets/AppIcon.icns" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+    <ItemGroup>
+        <AvaloniaXaml Update="Views/Dialogs/MessageDialog.axaml">
+            <SubType>Designer</SubType>
+        </AvaloniaXaml>
+        <AvaloniaXaml Update="Views/Dialogs/ExportDialog.axaml">
+            <SubType>Designer</SubType>
+        </AvaloniaXaml>
+        <AvaloniaXaml Update="Views/Dialogs/ProgressDialog.axaml">
+            <SubType>Designer</SubType>
+        </AvaloniaXaml>
+        <AvaloniaXaml Update="Views/Dialogs/ConfirmationDialog.axaml">
+            <SubType>Designer</SubType>
+        </AvaloniaXaml>
+        <AvaloniaXaml Update="Views/UserControls/DiagramView.axaml">
+            <SubType>Designer</SubType>
+        </AvaloniaXaml>
+        <AvaloniaXaml Update="Views/UserControls/MermaidEditorView.axaml">
+            <SubType>Designer</SubType>
+        </AvaloniaXaml>
+        <AvaloniaXaml Update="Views/SplashWindow.axaml">
+            <SubType>Designer</SubType>
+        </AvaloniaXaml>
+    </ItemGroup>
 
-	<!-- Import custom targets for asset hash generation -->
-	<Import Project="MermaidPad.Build.targets" />
-	<ItemGroup>
-		<!-- No need to explicitly include generated asset hash file in compilation -->
-		<!-- Doing so will cause NETSDK1022 Duplicate compile items error -->
-		<!--<Compile Include="Generated/AssetHashes.cs" Condition="Exists('Generated/AssetHashes.cs')" />-->
-	
-	  <None Update="LICENSE.TXT">
-	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	  </None>
-	</ItemGroup>
+    <!-- Import custom targets for asset hash generation -->
+    <Import Project="MermaidPad.Build.targets" />
+    <ItemGroup>
+        <!-- No need to explicitly include generated asset hash file in compilation -->
+        <!-- Doing so will cause NETSDK1022 Duplicate compile items error -->
+        <!--<Compile Include="Generated/AssetHashes.cs" Condition="Exists('Generated/AssetHashes.cs')" />-->
+
+        <None Update="LICENSE.TXT">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
 </Project>

--- a/ViewModels/UserControls/DiagramViewModel.cs
+++ b/ViewModels/UserControls/DiagramViewModel.cs
@@ -1,0 +1,205 @@
+// MIT License
+// Copyright (c) 2025 Dave Black
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Avalonia.Threading;
+using AvaloniaWebView;
+using CommunityToolkit.Mvvm.ComponentModel;
+using MermaidPad.Exceptions.Assets;
+using MermaidPad.Services;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MermaidPad.ViewModels.UserControls;
+
+/// <summary>
+/// Represents the ViewModel for the DiagramView UserControl, providing properties and actions
+/// for WebView initialization, rendering, and state management.
+/// </summary>
+/// <remarks>
+/// This ViewModel exposes state properties for data binding in the diagram preview UserControl, including
+/// readiness state and error information. It coordinates interactions between the user interface
+/// and the MermaidRenderer service. All properties and commands are designed for use with MVVM
+/// frameworks and are intended to be accessed by the View for UI updates and user interactions.
+/// </remarks>
+[SuppressMessage("ReSharper", "MemberCanBeMadeStatic.Global", Justification = "ViewModel properties are instance-based for binding.")]
+[SuppressMessage("ReSharper", "PropertyCanBeMadeInitOnly.Global", Justification = "ViewModel properties are set during initialization by the MVVM framework.")]
+[SuppressMessage("ReSharper", "MemberCanBePrivate.Global", Justification = "ViewModel properties are accessed by the view for data binding.")]
+[SuppressMessage("ReSharper", "UnusedMember.Global", Justification = "ViewModel members are accessed by the view for data binding.")]
+[SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated via ViewModelFactory.")]
+internal sealed partial class DiagramViewModel : ViewModelBase
+{
+    private readonly ILogger<DiagramViewModel> _logger;
+    private readonly MermaidRenderer _mermaidRenderer;
+    private const int WebViewReadyTimeoutSeconds = 30;
+
+    #region State Properties
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the WebView is ready for rendering operations.
+    /// </summary>
+    [ObservableProperty]
+    public partial bool IsReady { get; set; }
+
+    /// <summary>
+    /// Gets or sets the last error message, if any.
+    /// </summary>
+    [ObservableProperty]
+    public partial string? LastError { get; set; }
+
+    #endregion State Properties
+
+    #region Action Delegates
+
+    /// <summary>
+    /// Gets or sets the function to invoke when initializing the WebView.
+    /// </summary>
+    /// <remarks>
+    /// This function is set by DiagramView to implement the actual WebView initialization.
+    /// The function should initialize the MermaidRenderer with the WebView control and
+    /// perform the initial render of the current diagram text.
+    /// </remarks>
+    public Func<string, Task>? InitializeActionAsync { get; internal set; }
+
+    #endregion Action Delegates
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DiagramViewModel"/> class.
+    /// </summary>
+    /// <param name="logger">The <see cref="ILogger{DiagramViewModel}"/> instance for this view model.</param>
+    /// <param name="mermaidRenderer">The <see cref="MermaidRenderer"/> service for diagram rendering.</param>
+    public DiagramViewModel(ILogger<DiagramViewModel> logger, MermaidRenderer mermaidRenderer)
+    {
+        _logger = logger;
+        _mermaidRenderer = mermaidRenderer;
+    }
+
+    /// <summary>
+    /// Initializes the WebView asynchronously by invoking the initialization action set by the View.
+    /// </summary>
+    /// <param name="mermaidSource">The Mermaid source code to render. If the source is null, empty,
+    /// or consists only of whitespace, the output in the WebView will be cleared instead.</param>
+    /// <returns>A task representing the asynchronous initialization operation.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if InitializeAction has not been set.</exception>
+    public Task InitializeAsync(string mermaidSource)
+    {
+        // Do not check mermaidSource; null, empty and whitespace are valid values because that clears the diagram
+        if (InitializeActionAsync is null)
+        {
+            const string error = $"{nameof(InitializeActionAsync)} was not correctly set by DiagramView; fix the implementation so this delegate is initialized correctly. The WebView initialization action is not available.";
+            _logger.LogCritical(error);
+            throw new InvalidOperationException(error);
+        }
+
+        return InitializeActionAsync(mermaidSource);
+    }
+
+    /// <summary>
+    /// Renders a Mermaid diagram asynchronously by invoking the render action set by the View.
+    /// </summary>
+    /// <param name="mermaidSource">The Mermaid source code to render. If the source is null, empty,
+    /// or consists only of whitespace, the output in the WebView will be cleared instead.</param>
+    /// <returns>A task representing the asynchronous render operation.</returns>
+    public Task RenderAsync(string mermaidSource)
+    {
+        // Do not check mermaidSource; null, empty and whitespace are valid values because that clears the diagram
+        return _mermaidRenderer.RenderAsync(mermaidSource);
+    }
+
+    /// <summary>
+    /// Initializes the Mermaid renderer with the specified WebView and prepares it for rendering the provided Mermaid
+    /// diagram source asynchronously.
+    /// </summary>
+    /// <remarks>If the WebView does not become ready within the configured timeout, initialization continues
+    /// with a warning and some features may not function correctly. Asset-related exceptions are propagated to the
+    /// caller for higher-level handling. This method must be awaited to ensure the renderer is fully initialized before
+    /// issuing rendering commands.</remarks>
+    /// <param name="preview">The WebView instance to be initialized for rendering Mermaid diagrams. Cannot be null.</param>
+    /// <param name="mermaidSource">The Mermaid source code to render. If the source is null, empty,
+    /// or consists only of whitespace, the output in the WebView will be cleared instead.</param>
+    /// <returns>A task that represents the asynchronous initialization operation.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="preview"/> is null.</exception>
+    public Task InitializeWithRenderingAsync(WebView preview, string mermaidSource)
+    {
+        ArgumentNullException.ThrowIfNull(preview);
+        // Do not check mermaidSource; null, empty and whitespace are valid values because that clears the diagram
+
+        return InitializeWithRenderingCoreAsync(preview, mermaidSource);
+    }
+
+    /// <summary>
+    /// Initializes the Mermaid rendering environment using the specified WebView and Mermaid source code
+    /// asynchronously.
+    /// </summary>
+    /// <remarks>If the WebView does not become ready within the configured timeout, initialization continues
+    /// with a warning and some features may not function correctly. Asset-related exceptions are propagated to the
+    /// caller for higher-level handling. The method logs initialization progress and errors for diagnostic
+    /// purposes.</remarks>
+    /// <param name="preview">The WebView instance to be initialized for rendering Mermaid diagrams. Must not be null.</param>
+    /// <param name="mermaidSource">The Mermaid source code to render. If the source is null, empty,
+    /// or consists only of whitespace, the output in the WebView will be cleared instead.</param>
+    /// <returns>A task that represents the asynchronous initialization operation.</returns>
+    private async Task InitializeWithRenderingCoreAsync(WebView preview, string mermaidSource)
+    {
+        try
+        {
+            // Initialize MermaidRenderer with WebView
+            await _mermaidRenderer.InitializeAsync(preview);
+
+            // Kick first render; index.html sets globalThis.__renderingComplete__ in hideLoadingIndicator()
+            await _mermaidRenderer.RenderAsync(mermaidSource);
+
+            // Await readiness
+            try
+            {
+                await _mermaidRenderer.EnsureFirstRenderReadyAsync(TimeSpan.FromSeconds(WebViewReadyTimeoutSeconds));
+                await Dispatcher.UIThread.InvokeAsync(() => IsReady = true);
+                _logger.LogInformation("WebView readiness observed");
+            }
+            catch (TimeoutException tex)
+            {
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    IsReady = true;
+                    LastError = $"WebView initialization timed out after {WebViewReadyTimeoutSeconds} seconds. Some features may not work correctly.";
+                });
+                _logger.LogWarning(tex, "WebView readiness timed out after {TimeoutSeconds}s; enabling with warning", WebViewReadyTimeoutSeconds);
+            }
+
+            _logger.LogInformation("=== WebView Initialization Completed Successfully ===");
+        }
+        catch (OperationCanceledException ocex)
+        {
+            // Treat cancellations distinctly; still propagate
+            _logger.LogInformation(ocex, "WebView initialization was canceled.");
+            throw;
+        }
+        catch (Exception ex) when (ex is AssetIntegrityException or MissingAssetException)
+        {
+            // Let asset-related exceptions bubble up for higher-level handling
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Log and rethrow so caller can handle the failure
+            _logger.LogError(ex, "Error during {Method}", nameof(InitializeWithRenderingAsync));
+            throw;
+        }
+    }
+}

--- a/Views/MainWindow.axaml
+++ b/Views/MainWindow.axaml
@@ -5,7 +5,6 @@
   xmlns:local="clr-namespace:MermaidPad"
   xmlns:uc="clr-namespace:MermaidPad.Views.UserControls"
   xmlns:vm="clr-namespace:MermaidPad.ViewModels"
-  xmlns:wv="clr-namespace:AvaloniaWebView;assembly=Avalonia.WebView"
   Title="{Binding WindowTitle}"
   Width="1200"
   Height="800"
@@ -130,7 +129,7 @@
         Content="Live Preview:"
         FlowDirection="RightToLeft"
         IsChecked="{Binding LivePreviewEnabled}"
-        IsEnabled="{Binding IsWebViewReady}"
+        IsEnabled="{Binding Diagram.IsReady}"
         ToolTip.Tip="Toggle Live Preview" />
       <!--<TextBlock Margin="20,0,4,0" Text="Bundled:" />
       <TextBlock Text="{Binding BundledMermaidVersion}" />
@@ -152,7 +151,7 @@
         Text="{Binding StatusText}" />
     </StackPanel>
 
-    <!--  Main Content (your existing GridSplitter, Editor, WebView)  -->
+    <!--  Main Content (GridSplitter, Editor, DiagramView)  -->
     <Grid DockPanel.Dock="Top">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="*" />
@@ -174,26 +173,12 @@
         Background="Transparent"
         ResizeDirection="Columns" />
 
-      <!--  WebView Panel  -->
-      <Border
+      <!--  Diagram View UserControl  -->
+      <uc:DiagramView
+        x:Name="DiagramPreview"
         Grid.Column="2"
         Margin="0,0,6,6"
-        BorderBrush="LightGray"
-        BorderThickness="1"
-        CornerRadius="4">
-        <Grid>
-          <wv:WebView Name="Preview" />
-          <TextBlock
-            Margin="10"
-            HorizontalAlignment="Left"
-            VerticalAlignment="Top"
-            FontSize="11"
-            Foreground="Red"
-            IsVisible="{Binding LastError, Converter={x:Static ObjectConverters.IsNotNull}}"
-            Text="{Binding LastError}"
-            TextWrapping="Wrap" />
-        </Grid>
-      </Border>
+        DataContext="{Binding Diagram}" />
     </Grid>
   </DockPanel>
 </Window>

--- a/Views/UserControls/DiagramView.axaml
+++ b/Views/UserControls/DiagramView.axaml
@@ -1,0 +1,35 @@
+<UserControl
+  x:Class="MermaidPad.Views.UserControls.DiagramView"
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:vm="clr-namespace:MermaidPad.ViewModels.UserControls"
+  xmlns:wv="clr-namespace:AvaloniaWebView;assembly=Avalonia.WebView"
+  d:DesignHeight="450"
+  d:DesignWidth="800"
+  x:DataType="vm:DiagramViewModel"
+  mc:Ignorable="d">
+
+  <!--  WebView Panel with Border  -->
+  <Border
+    BorderBrush="LightGray"
+    BorderThickness="1"
+    CornerRadius="4">
+    <Grid>
+      <!--  WebView for rendering Mermaid diagrams  -->
+      <wv:WebView x:Name="Preview" />
+
+      <!--  Error overlay displayed when LastError is set  -->
+      <TextBlock
+        Margin="10"
+        HorizontalAlignment="Left"
+        VerticalAlignment="Top"
+        FontSize="11"
+        Foreground="Red"
+        IsVisible="{Binding LastError, Converter={x:Static ObjectConverters.IsNotNull}}"
+        Text="{Binding LastError}"
+        TextWrapping="Wrap" />
+    </Grid>
+  </Border>
+</UserControl>

--- a/Views/UserControls/DiagramView.axaml.cs
+++ b/Views/UserControls/DiagramView.axaml.cs
@@ -1,0 +1,199 @@
+// MIT License
+// Copyright (c) 2025 Dave Black
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Avalonia.Controls;
+using MermaidPad.Exceptions.Assets;
+using MermaidPad.Extensions;
+using MermaidPad.ViewModels.UserControls;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
+
+namespace MermaidPad.Views.UserControls;
+
+/// <summary>
+/// A UserControl that provides a WebView for rendering Mermaid diagrams with pan/zoom capabilities.
+/// </summary>
+/// <remarks>
+/// This control encapsulates all WebView-related functionality including:
+/// <list type="bullet">
+///     <item><description>WebView initialization and lifecycle management</description></item>
+///     <item><description>MermaidRenderer coordination</description></item>
+///     <item><description>Error display overlay</description></item>
+///     <item><description>Proper event handler cleanup</description></item>
+/// </list>
+/// </remarks>
+public sealed partial class DiagramView : UserControl
+{
+    private DiagramViewModel? _vm;
+    private readonly ILogger<DiagramView> _logger;
+
+    private bool _areViewModelEventHandlersCleanedUp;
+    private bool _areAllEventHandlersCleanedUp;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DiagramView"/> class.
+    /// </summary>
+    /// <remarks>
+    /// The constructor resolves required services from the application's DI container.
+    /// The ViewModel is expected to be set via the DataContext property.
+    /// </remarks>
+    public DiagramView()
+    {
+        InitializeComponent();
+
+        IServiceProvider sp = App.Services;
+        _logger = sp.GetRequiredService<ILogger<DiagramView>>();
+
+        _logger.LogInformation("=== DiagramView Initialization Started ===");
+
+        // Subscribe to DataContext changes to wire up the ViewModel
+        DataContextChanged += OnDataContextChanged;
+
+        _logger.LogInformation("=== DiagramView Initialization Completed ===");
+    }
+
+    /// <summary>
+    /// Handles changes to the DataContext, setting up or tearing down ViewModel bindings.
+    /// </summary>
+    /// <param name="sender">The source of the event.</param>
+    /// <param name="e">The event arguments.</param>
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        // Unsubscribe from previous ViewModel
+        if (_vm is not null)
+        {
+            UnsubscribeViewModelEventHandlers();
+        }
+
+        // Set up new ViewModel
+        if (DataContext is DiagramViewModel vm)
+        {
+            _vm = vm;
+            SetupViewModelBindings();
+        }
+        else
+        {
+            _vm = null;
+        }
+    }
+
+    /// <summary>
+    /// Sets up bindings and action delegates between the View and ViewModel.
+    /// </summary>
+    private void SetupViewModelBindings()
+    {
+        if (_vm is null)
+        {
+            return;
+        }
+
+        // Wire up action delegates
+        _vm.InitializeActionAsync = InitializeWebViewAsync;
+
+        _areViewModelEventHandlersCleanedUp = false;
+
+        _logger.LogInformation("ViewModel bindings established for DiagramView");
+    }
+
+    #region WebView Initialization
+
+    /// <summary>
+    /// Initializes the WebView and prepares it to render the specified Mermaid diagram source asynchronously.
+    /// </summary>
+    /// <remarks>This method starts the WebView rendering process and logs initialization timing information.
+    /// If the associated ViewModel is null, the method logs a warning and does not perform initialization.</remarks>
+    /// <param name="mermaidSource">The Mermaid source code to render. If the source is null, empty,
+    /// or consists only of whitespace, the output in the WebView will be cleared instead.</param>
+    /// <returns>A task that represents the asynchronous initialization operation.</returns>
+    /// <exception cref="OperationCanceledException">Propagated if initialization is canceled.</exception>
+    /// <exception cref="AssetIntegrityException">Propagated for asset integrity errors.</exception>
+    /// <exception cref="MissingAssetException">Propagated when required assets are missing.</exception>
+    private async Task InitializeWebViewAsync(string mermaidSource)
+    {
+        if (_vm is null)
+        {
+            _logger.LogWarning($"{nameof(InitializeWebViewAsync)} called with null ViewModel");
+            return;
+        }
+
+        _logger.LogInformation("=== WebView Initialization Started ===");
+        Stopwatch stopwatch = Stopwatch.StartNew();
+
+        bool success = false;
+        try
+        {
+            // Initialize renderer (starts HTTP server + navigate)
+            await _vm.InitializeWithRenderingAsync(Preview, mermaidSource);
+
+            success = true;
+        }
+        finally
+        {
+            stopwatch.Stop();
+            _logger.LogTiming("WebView initialization", stopwatch.Elapsed, success);
+        }
+    }
+
+    #endregion WebView Initialization
+
+    #region Cleanup
+
+    /// <summary>
+    /// Unsubscribes all ViewModel-related event handlers and clears action delegates.
+    /// </summary>
+    private void UnsubscribeViewModelEventHandlers()
+    {
+        // Prevent double-unsubscribe
+        if (!_areViewModelEventHandlersCleanedUp)
+        {
+            if (_vm?.InitializeActionAsync is not null)
+            {
+                // Clear action delegates
+                _vm.InitializeActionAsync = null;
+            }
+
+            _areViewModelEventHandlersCleanedUp = true;
+        }
+    }
+
+    /// <summary>
+    /// Unsubscribes all event handlers when the control is being disposed.
+    /// </summary>
+    internal void UnsubscribeAllEventHandlers()
+    {
+        // Prevent double-unsubscribe
+        if (!_areAllEventHandlersCleanedUp)
+        {
+            UnsubscribeViewModelEventHandlers();
+
+            DataContextChanged -= OnDataContextChanged;
+
+            _logger.LogInformation("All DiagramView event handlers unsubscribed successfully");
+            _areAllEventHandlersCleanedUp = true;
+        }
+        else
+        {
+            _logger.LogWarning($"{nameof(UnsubscribeAllEventHandlers)} called multiple times; skipping subsequent call");
+        }
+    }
+
+    #endregion Cleanup
+}


### PR DESCRIPTION
#### PR Classification
Major architectural refactor to modularize the editor and diagram preview, improve maintainability, and enhance user experience.

Resolves #296 

#### PR Summary
This update restructures the MermaidPad application by introducing dedicated UserControls and ViewModels for the editor and diagram preview, centralizing related logic and improving separation of concerns. It also adds a splash screen, enhances error handling, and streamlines command routing and event management.
- MainWindowViewModel.cs: Refactored to delegate editor and diagram state to new Editor and Diagram ViewModels, with improved command and event handling.
- MainWindow.axaml/.axaml.cs: Replaced direct editor/WebView usage with new UserControls, updated menu/toolbar bindings, and modularized event cleanup.
- MermaidEditorView.axaml/.axaml.cs & MermaidEditorViewModel.cs: Added UserControl and ViewModel for all editor logic, including clipboard, undo/redo, find, comment/uncomment, and IntelliSense.
- DiagramView.axaml/.axaml.cs & DiagramViewModel.cs: Added UserControl and ViewModel for diagram preview, handling WebView initialization, rendering, and error display.
- SplashWindow.axaml/.axaml.cs & SplashWindowViewModel.cs: Introduced a splash screen with version and copyright.

