### PR TITLE
Add target-branch for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,15 @@ version: 2
 updates:
   - package-ecosystem: "nuget" # See documentation for possible values
     directory: "/" # Location of package manifests
+    target-branch: "develop"
     schedule:
       interval: "weekly"
 
   # Enable version updates for GitHub Actions 
   - package-ecosystem: "github-actions" 
-    # Workflow files stored in the default location of `.github/workflows` 
+    # Workflow files stored in the default location of `.github/workflows`
     # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`. 
-    directory: "/" 
-    schedule: 
+    directory: "/"
+    target-branch: "develop"
+    schedule:
       interval: "weekly"


### PR DESCRIPTION
This pull request updates the Dependabot configuration to ensure that dependency update pull requests are created against the `develop` branch instead of the default branch. This helps keep development dependencies up-to-date without affecting the main branch.

Dependabot configuration updates:

* Set the `target-branch` to `develop` for both NuGet and GitHub Actions package ecosystems in `.github/dependabot.yml` so that updates are proposed to the `develop` branch. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R10) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R19)