### PR TITLE
#305 - feat: add tooltip and open link to status bar file

### DIFF
--- a/Views/MainWindow.axaml
+++ b/Views/MainWindow.axaml
@@ -144,11 +144,50 @@
         HorizontalAlignment="Right"
         VerticalAlignment="Center"
         Text="{Binding Source={x:Static local:AppMetadata.FileVersion}, Mode=OneTime}" />
-      <TextBlock
+      <StackPanel
         Margin="12,0,0,0"
         VerticalAlignment="Center"
-        Foreground="Gray"
-        Text="{Binding StatusText}" />
+        Orientation="Horizontal">
+        <Button
+          Background="Transparent"
+          BorderBrush="{x:Null}"
+          BorderThickness="0"
+          Command="{Binding OpenFileLocationCommand}"
+          Cursor="Hand"
+          IsVisible="False"
+          ToolTip.Tip="{Binding CurrentFilePath}">
+          <Button.Content>
+            <TextBlock
+              Foreground="Gray"
+              Text="{Binding StatusText}"
+              TextDecorations="Underline" />
+          </Button.Content>
+          <Button.Styles>
+            <Style Selector="Button">
+              <Style.Triggers>
+                <DataTrigger Binding="{Binding HasOpenFile}" Value="True">
+                  <Setter Property="IsVisible" Value="True" />
+                </DataTrigger>
+              </Style.Triggers>
+            </Style>
+          </Button.Styles>
+        </Button>
+        <TextBlock
+          VerticalAlignment="Center"
+          Foreground="Gray"
+          Text="{Binding StatusText}"
+          ToolTip.Tip="{Binding CurrentFilePath}">
+          <TextBlock.Styles>
+            <Style Selector="TextBlock">
+              <Style.Triggers>
+                <DataTrigger Binding="{Binding HasOpenFile}" Value="True">
+                  <Setter Property="IsVisible" Value="False" />
+                </DataTrigger>
+              </Style.Triggers>
+            </Style>
+          </TextBlock.Styles>
+        </TextBlock>
+      </StackPanel>
     </StackPanel>
 
     <!--  Main Content (GridSplitter, Editor, DiagramView)  -->


### PR DESCRIPTION
## Summary
- show full file path as a tooltip on the status bar file name
- add a clickable link in the status bar to open the file location in the system file explorer when a file is open
- hide the link when no file is open, keeping the status text visible

## Rationale
- improves usability of the status bar by exposing the full path and quick access to the file location (issue #305)

## Changes
- add HasOpenFile flag and OpenFileLocation command to main view model
- update status bar layout to render a link-style button with tooltip and fallback text when no file is open

Fixes #305