### PR TITLE
feat: Add WordWrap and ShowLineNumbers editor options

### DIFF
--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -67,6 +67,22 @@ public sealed class AppSettings
     public bool LivePreviewEnabled { get; set; } = true;
 
     /// <summary>
+    /// This indiacates whether word wrap is enabled or not.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
+    public bool WordWrapEnabled { get; set; } = false;
+
+    /// <summary>
+    /// This indicates whether line numbers are shown in the editor.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>true</c>.
+    /// </remarks>
+    public bool ShowLineNumbers { get; set; } = true;
+
+    /// <summary>
     /// The zero-based start index of the editor selection.
     /// </summary>
     public int EditorSelectionStart { get; set; }

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -135,6 +135,36 @@ internal sealed partial class MainWindowViewModel : ViewModelBase, IDisposable
     public partial bool LivePreviewEnabled { get; set; }
 
     /// <summary>
+    /// This will get or set the value indicating whether word wrap is enabled in the editor.
+    /// </summary>
+    [ObservableProperty]
+    public partial bool WordWrapEnabled { get; set; }
+
+    /// <summary>
+    /// Called when wordwrapengabled changes; persists the new value to settings.
+    /// </summary>
+    partial void OnWordWrapEnabledChanged(bool value)
+    {
+        _settingsService.Settings.WordWrapEnabled = value;
+        _settingsService.Save();
+    }
+
+    /// <summary>
+    /// This will get or set the value indicating whether a line number is shown in the editor.
+    /// </summary>
+    [ObservableProperty]
+    public partial bool ShowLineNumbers { get; set; }
+
+    /// <summary>
+    /// Called when ShowLineNumbers changes; persists the new value to settings.
+    /// </summary>
+    partial void OnShowLineNumbersChanged(bool value)
+    {
+        _settingsService.Settings.ShowLineNumbers = value;
+        _settingsService.Save();
+    }
+
+    /// <summary>
     /// Gets or sets the current file path being edited.
     /// </summary>
     [ObservableProperty]
@@ -208,6 +238,8 @@ internal sealed partial class MainWindowViewModel : ViewModelBase, IDisposable
         BundledMermaidVersion = _settingsService.Settings.BundledMermaidVersion;
         LatestMermaidVersion = _settingsService.Settings.LatestCheckedMermaidVersion;
         LivePreviewEnabled = _settingsService.Settings.LivePreviewEnabled;
+        WordWrapEnabled = _settingsService.Settings.WordWrapEnabled;
+        ShowLineNumbers = _settingsService.Settings.ShowLineNumbers;
         CurrentFilePath = _settingsService.Settings.CurrentFilePath;
 
         // Subscribe to Editor.PropertyChanged to forward Text/HasText changes

--- a/Views/MainWindow.axaml
+++ b/Views/MainWindow.axaml
@@ -99,6 +99,17 @@
           Command="{Binding Editor.UncommentSelectionCommand}"
           Header="_Uncomment Selection"
           InputGesture="Ctrl+Shift+U" />
+        <Separator />
+        <MenuItem Header="Formatting">
+          <MenuItem 
+            Header="Word _Wrap" 
+            IsChecked="{Binding WordWrapEnabled, Mode=TwoWay}" 
+            ToggleType="CheckBox" />
+          <MenuItem 
+            Header="Show _Line Numbers" 
+            IsChecked="{Binding ShowLineNumbers, Mode=TwoWay}" 
+            ToggleType="CheckBox" />
+        </MenuItem>
       </MenuItem>
       <MenuItem Header="_Help">
         <MenuItem Command="{Binding ViewLogsCommand}" Header="View _Logs" />

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -83,7 +83,30 @@ public sealed partial class MainWindow : Window
         _activatedHandler = OnActivated;
         Activated += _activatedHandler;
 
+        // Subscribe to ViewModel property changes for WordWrap and ShowLineNumbers
+        _vm.PropertyChanged += OnMainViewModelPropertyChanged;
+
+        // Apply initial editor settings
+        MermaidEditor.SetWordWrap(_vm.WordWrapEnabled);
+        MermaidEditor.SetShowLineNumbers(_vm.ShowLineNumbers);
+
         _logger.LogInformation("=== MainWindow Initialization Completed ===");
+    }
+
+    /// <summary>
+    /// Handles property changes from the MainWindowViewModel to apply editor settings.
+    /// </summary>
+    private void OnMainViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(MainWindowViewModel.WordWrapEnabled):
+                MermaidEditor.SetWordWrap(_vm.WordWrapEnabled);
+                break;
+            case nameof(MainWindowViewModel.ShowLineNumbers):
+                MermaidEditor.SetShowLineNumbers(_vm.ShowLineNumbers);
+                break;
+        }
     }
 
     /// <summary>
@@ -412,6 +435,9 @@ public sealed partial class MainWindow : Window
                 Activated -= _activatedHandler;
                 _activatedHandler = null;
             }
+
+            // Unsubscribe from ViewModel property changes
+            _vm.PropertyChanged -= OnMainViewModelPropertyChanged;
 
             _logger.LogInformation("All MainWindow event handlers unsubscribed successfully");
 

--- a/Views/UserControls/MermaidEditorView.axaml.cs
+++ b/Views/UserControls/MermaidEditorView.axaml.cs
@@ -1497,5 +1497,35 @@ public sealed partial class MermaidEditorView : UserControl
         }
     }
 
+    /// <summary>
+    /// Sets whether word wrap is enabled in the editor.
+    /// </summary>
+    /// <param name="enabled"><c>true</c> to enable word wrap; otherwise, <c>false</c>.</param>
+    public void SetWordWrap(bool enabled)
+    {
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            Editor.WordWrap = enabled;
+            return;
+        }
+
+        Dispatcher.UIThread.Post(() => Editor.WordWrap = enabled, DispatcherPriority.Normal);
+    }
+
+    /// <summary>
+    /// Sets whether line numbers are shown in the editor.
+    /// </summary>
+    /// <param name="show"><c>true</c> to show line numbers; otherwise, <c>false</c>.</param>
+    public void SetShowLineNumbers(bool show)
+    {
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            Editor.ShowLineNumbers = show;
+            return;
+        }
+
+        Dispatcher.UIThread.Post(() => Editor.ShowLineNumbers = show, DispatcherPriority.Normal);
+    }
+
     #endregion Cleanup
 }


### PR DESCRIPTION
- Add WordWrapEnabled and ShowLineNumbers properties to AppSettings for persistence
- Add observable properties with OnChanged handlers in MainWindowViewModel
- Add Formatting submenu under Edit menu with toggle checkboxes
- Wire up MainWindow to apply settings to MermaidEditorView
- Add SetWordWrap and SetShowLineNumbers public methods to MermaidEditorView

Closes #224

﻿🎉 Thank you for contributing to MermaidPad! 🚀

Please review the checklist to help ensure high-quality submissions.

---

## Summary of Changes
Added WordWrap and ShowLineNumbers toggle options to the Edit menu, allowing users to customize their editor experience. Settings persist across application sessions.

## Contributor Checklist ✅
<!-- Please review and check off the following items before submitting your PR. -->
- [x] I based my branch on **develop** and all commits are rebased (no merge commits).
- [x] I tested my changes in both **DEBUG** and **RELEASE** builds.
- [x] I followed existing architectural patterns and coding conventions.
- [x] If my PR modifies ***.cs files***, I reviewed <u>all warnings related to my changes and resolved them</u>.
- [x] Async code correctly marshals UI interactions to the UI thread.
- [ ] If my PR modifies **JavaScript**, I ran `eslint` (v9+) and <u>fixed any reported warnings or errors</u>.
- [x] My changes do not use OS-specific APIs unless implemented through the PlatformServices abstraction.

## Additional Notes
- The feature follows the existing MVVM pattern used throughout the codebase
- Settings are immediately persisted when toggled via the `SettingsService`
- Default values: WordWrap = OFF, ShowLineNumbers = ON

