### PR TITLE
#347 - Add Build Scripts, fix compile errors in RELEASE, fix broken images on README

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -27,8 +27,12 @@ using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
 using AvaloniaWebView;
+// Only include Dock developer tools in debug builds. MermaidPad.csproj conditionally includes
+// the AvaloniaUI.DiagnosticsSupport and Dock.Avalonia.Diagnostics packages reference based on DEBUG symbol
+#if DEBUG
 using Dock.Avalonia.Diagnostics;
 using Dock.Avalonia.Diagnostics.Controls;
+#endif
 using MermaidPad.Infrastructure;
 using MermaidPad.Models;
 using MermaidPad.ViewModels;
@@ -76,10 +80,12 @@ public sealed partial class App : Application, IDisposable
     private int _errorDialogPumpScheduled;
     private int _shutdownRequested;
 
+#if DEBUG
     // Developer Tools
     private IAsyncDisposable? _avaloniaDevToolsDisposable;
     private IDisposable? _dockDebugDisposable;
     private IDisposable? _dockDebugOverlayDisposable;
+#endif
 
     /// <summary>
     /// Initializes the component and loads its associated XAML content.
@@ -91,11 +97,14 @@ public sealed partial class App : Application, IDisposable
     {
         AvaloniaXamlLoader.Load(this);
 
+#if DEBUG
         AttachAvaloniaDeveloperTools();
+#endif
     }
 
     #region Developer Tools methods
 
+#if DEBUG
     /// <summary>
     /// Attaches the Avalonia developer tools to the current window for debugging purposes in debug builds.
     /// </summary>
@@ -127,7 +136,6 @@ public sealed partial class App : Application, IDisposable
     /// </para>
     /// </remarks>
     /// <param name="mainWindow">The main application window to which the Dock developer tools will be attached. Cannot be null.</param>
-    [Conditional("DEBUG")]
     private void AttachDockDeveloperTools(MainWindow mainWindow)
     {
         Debug.Assert(mainWindow is not null, "MainWindow cannot be null when attaching Dock developer tools.");
@@ -146,7 +154,6 @@ public sealed partial class App : Application, IDisposable
     /// </summary>
     /// <remarks>This method is only invoked when the application is compiled in debug mode. Disposal is
     /// performed synchronously to ensure that all resources are released before continuing execution.</remarks>
-    [Conditional("DEBUG")]
     [SuppressMessage("Usage", "VSTHRD002:Avoid problematic synchronous waits", Justification = "Disposal must be synchronous in this context.")]
     private void DisposeDeveloperTools()
     {
@@ -157,6 +164,7 @@ public sealed partial class App : Application, IDisposable
 
         Log.Debug("Avalonia and Dock developer tools disposed");
     }
+#endif
 
     #endregion Developer Tools methods
 
@@ -255,7 +263,9 @@ public sealed partial class App : Application, IDisposable
         mainWindow.Show();
         mainWindow.Focus();
 
+#if DEBUG
         AttachDockDeveloperTools(mainWindow);
+#endif
 
         _desktopLifetime.MainWindow = mainWindow;
     }
@@ -1101,8 +1111,10 @@ public sealed partial class App : Application, IDisposable
                 UnregisterGlobalExceptionHandlers();
                 UnregisterDesktopLifetimeEvents();
 
+#if DEBUG
                 // Dispose developer tools if enabled (DEBUG only: conditionally-compiled)
                 DisposeDeveloperTools();
+#endif
 
                 // Dispose managed services since we built and managed the ServiceProvider ourselves (async-aware)
                 if (Services is IAsyncDisposable asyncDisposableServices)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,9 +39,8 @@
             No additional publish configuration is needed in this file.
         -->
         <!-- Embed build target RID as compile-time constant for platform compatibility checking -->
-        <DefineConstants Condition="'$(RuntimeIdentifier)' != ''">
-            $(DefineConstants);BUILT_FOR_$(RuntimeIdentifier.Replace("-", "_").ToUpperInvariant())
-        </DefineConstants>
+        <!-- Keep this DefineConstants on the same line to avoid introducing unnecessary whitespace into the /define -->
+        <DefineConstants Condition="'$(RuntimeIdentifier)' != ''">$(DefineConstants);BUILT_FOR_$(RuntimeIdentifier.Replace('-', '_').ToUpperInvariant())</DefineConstants>
     </PropertyGroup>
 
     <!-- CI-stamped metadata (only present when the workflow passes these properties) -->

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ classDiagram-v2
     Animal <|-- Insect
 ```
 
-<img width="2319" height="1365" alt="Class Diagram Example" src="<https://github.com/user-attachments/assets/51c8a3e2-d48f-4090-959c-90cc7537bf2a"> />
+![Class Diagram Example](https://github.com/user-attachments/assets/51c8a3e2-d48f-4090-959c-90cc7537bf2a){width=600}
 </details>
 
 <details>
@@ -430,7 +430,7 @@ gantt
     Task 6 :after a5, 15d
 ```
 
-<img width="2318" height="1360" alt="Gantt Chart Example" src="<https://github.com/user-attachments/assets/8b3179ea-e73c-4877-9284-e0b33f9f9390"> />
+![Gantt Chart Example](https://github.com/user-attachments/assets/8b3179ea-e73c-4877-9284-e0b33f9f9390){width=600}
 </details>
 
 <details>
@@ -476,7 +476,7 @@ graph TD
     G --> N[SUCCESS - builds both as needed]
 ```
 
-<img width="3833" height="2070" alt="Graph Example" src="<https://github.com/user-attachments/assets/75df1b41-f573-4a99-acfc-72ee978af17a"> />
+![Graph Example](https://github.com/user-attachments/assets/75df1b41-f573-4a99-acfc-72ee978af17a){width=600}
 </details>
 
 <details>
@@ -576,7 +576,7 @@ pie
     "Others": 10
 ```
 
-<img width="2315" height="1362" alt="Pie Chart Example" src="<https://github.com/user-attachments/assets/3f7a7c94-6ce9-4954-a4de-bdc061027a2b"> />
+![Pie Chart Example](https://github.com/user-attachments/assets/3f7a7c94-6ce9-4954-a4de-bdc061027a2b){width=600}
 </details>
 
 <details>
@@ -740,7 +740,7 @@ sequenceDiagram
     Bob-->>John: Jolly good!
 ```
 
-<img width="2317" height="1364" alt="Sequence Diagram Example" src="<https://github.com/user-attachments/assets/4a263479-4d43-41c3-a86d-c7e3263d7959"> />
+![Sequence Diagram Example](https://github.com/user-attachments/assets/4a263479-4d43-41c3-a86d-c7e3263d7959){width=600}
 </details>
 
 <details>
@@ -784,7 +784,7 @@ stateDiagram-v2
     if_state --> True : if n >= 0
 ```
 
-<img width="2320" height="1361" alt="State Diagram Example" src="<https://github.com/user-attachments/assets/9c7bf077-9272-4a34-89b4-f0572e5168be"> />
+![State Diagram Example](https://github.com/user-attachments/assets/9c7bf077-9272-4a34-89b4-f0572e5168be){width=600}
 </details>
 
 <details>
@@ -982,7 +982,7 @@ Visit the [Releases page](https://github.com/udlose/MermaidPad/releases/latest) 
 
 ## Usage
 
-<img width="2318" height="1381" alt="MermaidPad UI" src="<https://github.com/user-attachments/assets/bba73b63-e908-493e-829c-99a74adeba61"> />
+![MermaidPad UI](https://github.com/user-attachments/assets/bba73b63-e908-493e-829c-99a74adeba61){width=600}
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [![Last Commit](https://img.shields.io/github/last-commit/udlose/MermaidPad?style=flat-square)](https://github.com/udlose/MermaidPad/commits/main)
 [![License](https://img.shields.io/github/license/udlose/MermaidPad?style=flat-square)](https://github.com/udlose/MermaidPad/blob/main/LICENSE.TXT)
 [![wakatime](https://wakatime.com/badge/github/udlose/MermaidPad.svg?style=flat-square)](https://wakatime.com/badge/github/udlose/MermaidPad)
-![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Floc-counter.onrender.com%2F%3Frepo%3Dudlose%2FMermaidPad%26branch%3Ddevelop&label=lines%20of%20code&color=orange)
+![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Floc-counter.onrender.com%2F%3Frepo%3Dudlose%2FMermaidPad%26branch%3Ddevelop&label=lines%20of%20code&color=orange&cacheSeconds=86400)
 
 <!--[![Lines of Code](https://img.shields.io/tokei/lines/github/udlose/MermaidPad?style=flat-square)]-->
 <!--[![Codacy Badge](https://app.codacy.com/project/badge/Grade/3f4e1f3f3b6e4e2fa6f3e4e2fa6f3e4e2)](https://www.codacy.com/gh/udlose/MermaidPad/dashboard?utm_source=github.com&utm_medium=referral&utm_content=udlose/MermaidPad&utm_campaign=Badge_Grade)-->

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,469 @@
+<#
+.SYNOPSIS
+    Builds and publishes MermaidPad for the current platform.
+
+.DESCRIPTION
+    This script builds and publishes MermaidPad for local development and testing.
+    It mirrors the CI/CD workflow in .github/workflows/build-and-release.yml to ensure
+    local builds produce artifacts identical to CI builds.
+
+    The script:
+    1. Detects the current OS and architecture
+    2. Restores NuGet packages
+    3. Publishes the application (which triggers asset hash generation)
+    4. Optionally creates a zip artifact matching CI naming convention
+
+.PARAMETER Version
+    The version string to embed in the build (e.g., "1.2.3").
+    Defaults to "1.0.0-localdev" for local development builds.
+
+.PARAMETER Configuration
+    Build configuration ("Debug" or "Release"). Defaults to "Debug".
+
+.PARAMETER Clean
+    If specified, removes previous build artifacts before building.
+
+.PARAMETER SkipZip
+    If specified, skips creating the zip artifact (faster for iteration).
+
+.PARAMETER OutputDirectory
+    The directory for build artifacts. Defaults to "./artifacts".
+
+.EXAMPLE
+    ./build.ps1
+    Builds for the current platform with Debug configuration and version "1.0.0-localdev".
+
+.EXAMPLE
+    ./build.ps1 -Configuration Release
+    Builds for the current platform using Release configuration.
+
+.EXAMPLE
+    ./build.ps1 -Version 1.2.3 -Configuration Release -Clean
+    Cleans previous artifacts and builds with version 1.2.3 using Release configuration.
+
+.EXAMPLE
+    ./build.ps1 -Version 1.2.3 -SkipZip -Verbose
+    Builds without creating a zip, with verbose output.
+
+.NOTES
+    Author: MermaidPad Contributors
+    Repository: https://github.com/udlose/MermaidPad
+
+    Prerequisites:
+    - .NET 9.0 SDK or later
+    - PowerShell 7.0 or later (recommended) or Windows PowerShell 5.1
+
+    This script is designed for local development and testing.
+    For releases, use the GitHub Actions workflow.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Version = "1.0.0-localdev",
+
+    [Parameter()]
+    [ValidateSet("Debug", "Release")]
+    [string]$Configuration = "Debug",
+
+    [Parameter()]
+    [switch]$Clean,
+
+    [Parameter()]
+    [switch]$SkipZip,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string]$OutputDirectory = "./artifacts"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+#region Helper Functions
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host ""
+    Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -ForegroundColor Cyan
+    Write-Host "  $Message" -ForegroundColor Cyan
+    Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -ForegroundColor Cyan
+}
+
+function Write-Success {
+    param([string]$Message)
+    Write-Host "✓ $Message" -ForegroundColor Green
+}
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host "  $Message" -ForegroundColor Gray
+}
+
+function Write-ErrorMessage {
+    param([string]$Message)
+    Write-Error "✗ $Message" -ErrorAction Continue
+}
+
+function Get-RuntimeIdentifier {
+    <#
+    .SYNOPSIS
+        Detects the current platform's Runtime Identifier (RID).
+    #>
+    [string]$os = ""
+    [string]$arch = ""
+
+    # Detect OS (compatible with Windows PowerShell 5.1 and PowerShell 6+)
+    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) {
+        $os = "win"
+    }
+    elseif ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Linux)) {
+        $os = "linux"
+    }
+    elseif ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::OSX)) {
+        $os = "osx"
+    }
+    else {
+        throw "Unable to detect operating system. Supported: Windows, Linux, macOS."
+    }
+
+    # Detect architecture
+    # Note: [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture is more reliable
+    [string]$osArch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+
+    switch ($osArch) {
+        "x64" { $arch = "x64" }
+        "arm64" { $arch = "arm64" }
+        default {
+            throw "Unsupported architecture: $osArch. Supported: x64, arm64."
+        }
+    }
+
+    # Validate against supported RIDs in Directory.Build.props
+    [string]$rid = "$os-$arch"
+    [string[]]$supportedRids = @("win-x64", "win-arm64", "linux-x64", "osx-x64", "osx-arm64")
+
+    if ($rid -notin $supportedRids) {
+        throw "Unsupported Runtime Identifier: $rid. Supported RIDs: $($supportedRids -join ', ')"
+    }
+
+    return $rid
+}
+
+function Get-ExecutableExtension {
+    param([string]$RuntimeIdentifier)
+
+    if ($RuntimeIdentifier.StartsWith("win")) {
+        return ".exe"
+    }
+
+    return ""
+}
+
+function Test-DotNetSdk {
+    <#
+    .SYNOPSIS
+        Validates that the .NET SDK is installed and meets minimum version requirements.
+    #>
+    try {
+        $dotnetVersion = & dotnet --version 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw ".NET SDK not found"
+        }
+
+        Write-Verbose "Detected .NET SDK version: $dotnetVersion"
+
+        # Parse major version - handle preview versions like "9.0.100-preview.1"
+        [string]$majorVersionString = $dotnetVersion.Split('.')[0]
+        [int]$majorVersion = 0
+
+        if (-not [int]::TryParse($majorVersionString, [ref]$majorVersion)) {
+            throw "Unable to parse .NET SDK version from 'dotnet --version' output: '$dotnetVersion'"
+        }
+
+        if ($majorVersion -lt 9) {
+            throw ".NET 9.0 SDK or later is required. Found: $dotnetVersion"
+        }
+
+        Write-Success ".NET SDK $dotnetVersion detected"
+    }
+    catch {
+        Write-ErrorMessage "Failed to detect .NET SDK: $_"
+        Write-Host ""
+        Write-Host "Please install the .NET 9.0 SDK from: https://dotnet.microsoft.com/download/dotnet/9.0" -ForegroundColor Yellow
+        throw
+    }
+}
+
+function Get-GitCommitSha {
+    <#
+    .SYNOPSIS
+        Gets the current Git commit SHA, or a placeholder if not in a Git repository.
+    #>
+    try {
+        [string]$sha = & git rev-parse HEAD 2>&1
+        if ($LASTEXITCODE -eq 0 -and $sha.Length -ge 7) {
+            return $sha.Trim()
+        }
+    }
+    catch {
+        Write-Verbose "Git not available or not in a repository: $_"
+    }
+
+    return "local-build"
+}
+
+#endregion
+
+#region Main Script
+
+try {
+    Write-Host ""
+    Write-Host "╔══════════════════════════════════════════════════════════════╗" -ForegroundColor Magenta
+    Write-Host "║               MermaidPad Build Script                        ║" -ForegroundColor Magenta
+    Write-Host "╚══════════════════════════════════════════════════════════════╝" -ForegroundColor Magenta
+
+    # Determine script and project locations
+    [string]$scriptDir = $PSScriptRoot
+    if ([string]::IsNullOrEmpty($scriptDir)) {
+        $scriptDir = Get-Location
+    }
+
+    [string]$projectFile = Join-Path -Path $scriptDir -ChildPath "MermaidPad.csproj"
+    if (-not (Test-Path -Path $projectFile)) {
+        throw "Project file not found: $projectFile. Ensure this script is in the repository root."
+    }
+
+    # Resolve output directory to absolute, canonical path
+    if (-not [System.IO.Path]::IsPathRooted($OutputDirectory)) {
+        $OutputDirectory = Join-Path -Path $scriptDir -ChildPath $OutputDirectory
+    }
+    $OutputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory)
+
+    # Step 1: Validate prerequisites
+    Write-Step "Validating Prerequisites"
+    Test-DotNetSdk
+
+    # Step 2: Detect platform
+    Write-Step "Detecting Platform"
+    [string]$rid = Get-RuntimeIdentifier
+    [string]$extension = Get-ExecutableExtension -RuntimeIdentifier $rid
+    Write-Success "Runtime Identifier: $rid"
+
+    # Step 3: Gather build metadata
+    Write-Step "Gathering Build Metadata"
+    [string]$buildDate = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    [string]$commitSha = Get-GitCommitSha
+    Write-Info "Version:        $Version"
+    Write-Info "Configuration:  $Configuration"
+    Write-Info "Build Date:     $buildDate"
+    Write-Info "Commit SHA:     $commitSha"
+
+    # Step 4: Clean if requested
+    function Validate-BuildPaths {
+        param(
+            [string]$Version,
+            [string]$OutputDirectory
+        )
+        [string]$invalidVersionPattern = '[\\/]|:|(\.\.)'
+        [string]$invalidOutputDirectoryPattern = '(\.\.)'
+        if ($Version -match $invalidVersionPattern) {
+            throw "Invalid Version value '$Version'. Version must not contain '/', '\', ':', or '..'."
+        }
+        if ($OutputDirectory -match $invalidOutputDirectoryPattern) {
+            throw "Invalid OutputDirectory value '$OutputDirectory'. OutputDirectory must not contain '..'."
+        }
+    }
+
+    function Get-BuildArtifactPaths {
+        param(
+            [string]$Version,
+            [string]$Configuration,
+            [string]$rid,
+            [string]$OutputDirectory
+        )
+        Validate-BuildPaths -Version $Version -OutputDirectory $OutputDirectory
+
+        [string]$publishDir = Join-Path -Path $OutputDirectory -ChildPath "MermaidPad-$Version-$Configuration-$rid"
+        $publishDir = [System.IO.Path]::GetFullPath($publishDir)
+
+        # Normalize and validate that publishDir is under OutputDirectory using an OS-appropriate comparison
+        [string]$resolvedOutputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory)
+        $directorySeparator = [System.IO.Path]::DirectorySeparatorChar
+        if (-not $resolvedOutputDirectory.EndsWith([string]$directorySeparator)) {
+            $resolvedOutputDirectory += $directorySeparator
+        }
+
+        if ($IsWindows) {
+            $comparison = [System.StringComparison]::OrdinalIgnoreCase
+        }
+        else {
+            $comparison = [System.StringComparison]::Ordinal
+        }
+
+        if (-not $publishDir.StartsWith($resolvedOutputDirectory, $comparison)) {
+            throw "Resolved publish directory '$publishDir' is not under the output directory '$OutputDirectory'."
+        }
+
+        [string]$zipName = "MermaidPad-$Version-$Configuration-$rid.zip"
+        [string]$zipPath = Join-Path -Path $OutputDirectory -ChildPath $zipName
+        $zipPath = [System.IO.Path]::GetFullPath($zipPath)
+
+        # Defense-in-depth: Ensure $zipPath is under $OutputDirectory
+        if (-not $zipPath.StartsWith($resolvedOutputDirectory, $comparison)) {
+            throw "Resolved zip path '$zipPath' is not under the output directory '$OutputDirectory'."
+        }
+
+        return @{
+            PublishDir = $publishDir
+            ZipName    = $zipName
+            ZipPath    = $zipPath
+        }
+    }
+
+    $artifactPaths = Get-BuildArtifactPaths -Version $Version -Configuration $Configuration -rid $rid -OutputDirectory $OutputDirectory
+    [string]$publishDir = $artifactPaths.PublishDir
+    [string]$zipName = $artifactPaths.ZipName
+    [string]$zipPath = $artifactPaths.ZipPath
+
+    if ($Clean) {
+        Write-Step "Cleaning Previous Artifacts"
+
+        if (Test-Path -Path $publishDir) {
+            Remove-Item -Path $publishDir -Recurse -Force
+            Write-Success "Removed: $publishDir"
+        }
+
+        if (Test-Path -Path $zipPath) {
+            Remove-Item -Path $zipPath -Force
+            Write-Success "Removed: $zipPath"
+        }
+
+        # Clean bin/obj directories
+        [string]$binDir = Join-Path -Path $scriptDir -ChildPath "bin"
+        [string]$objDir = Join-Path -Path $scriptDir -ChildPath "obj"
+
+        if (Test-Path -Path $binDir) {
+            Remove-Item -Path $binDir -Recurse -Force
+            Write-Success "Removed: bin/"
+        }
+
+        if (Test-Path -Path $objDir) {
+            Remove-Item -Path $objDir -Recurse -Force
+            Write-Success "Removed: obj/"
+        }
+    }
+
+    # Step 5: Restore dependencies
+    Write-Step "Restoring Dependencies"
+    Write-Verbose "Running: dotnet restore $projectFile"
+
+    & dotnet "restore" $projectFile
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet restore failed with exit code $LASTEXITCODE"
+    }
+    Write-Success "Dependencies restored"
+
+    # Step 6: Publish
+    Write-Step "Publishing Application"
+
+    # Ensure output directory exists
+    if (-not (Test-Path -Path $OutputDirectory)) {
+        New-Item -Path $OutputDirectory -ItemType Directory -Force | Out-Null
+    }
+
+    [string[]]$publishArgs = @(
+        "publish"
+        $projectFile
+        "-c", $Configuration
+        "-r", $rid
+        "-o", $publishDir
+        "-p:Version=$Version"
+        "-p:MermaidPadBuildDate=$buildDate"
+        "-p:MermaidPadCommitSha=$commitSha"
+    )
+
+    Write-Verbose "Running: dotnet $($publishArgs -join ' ')"
+
+    & dotnet @publishArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet publish failed with exit code $LASTEXITCODE"
+    }
+    Write-Success "Application published to: $publishDir"
+
+    # Step 7: Create zip artifact (unless skipped)
+    if (-not $SkipZip) {
+        Write-Step "Creating Zip Artifact"
+
+        # Use already validated and computed $zipPath from Get-BuildArtifactPaths
+        # No need to re-validate $Version or $OutputDirectory here
+
+        # Remove existing zip if present
+        if (Test-Path -Path $zipPath) {
+            Remove-Item -Path $zipPath -Force
+        }
+
+        # Create zip from publish directory contents
+        Write-Verbose "Creating zip: $zipPath"
+        Compress-Archive -Path (Join-Path -Path $publishDir -ChildPath '*') -DestinationPath $zipPath -Force
+
+        Write-Success "Zip artifact created: $zipPath"
+    }
+    else {
+        Write-Info "Skipping zip creation (-SkipZip specified)"
+    }
+
+    # Summary
+    Write-Host ""
+    Write-Host "╔══════════════════════════════════════════════════════════════╗" -ForegroundColor Green
+    Write-Host "║                    Build Complete!                           ║" -ForegroundColor Green
+    Write-Host "╚══════════════════════════════════════════════════════════════╝" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "  Artifacts:" -ForegroundColor White
+    Write-Host "    Publish Directory: $publishDir" -ForegroundColor Gray
+
+    if (-not $SkipZip) {
+        Write-Host "    Zip Artifact:      $zipPath" -ForegroundColor Gray
+    }
+
+    Write-Host ""
+    Write-Host "  To run the application:" -ForegroundColor White
+
+    [string]$executableName = "MermaidPad$extension"
+    [string]$executablePath = Join-Path -Path $publishDir -ChildPath $executableName
+
+    if ($rid.StartsWith("win")) {
+        Write-Host "    $executablePath" -ForegroundColor Gray
+    }
+    else {
+        if (Test-Path -LiteralPath $executablePath) {
+            try {
+                $chmodCommand = Get-Command chmod -ErrorAction SilentlyContinue
+                if ($null -ne $chmodCommand) {
+                    & $chmodCommand.Path +x -- $executablePath
+                }
+            }
+            catch {
+                Write-Verbose "Failed to set execute permission on '$executablePath': $_"
+            }
+        }
+        Write-Host "    chmod +x `"$executablePath`"" -ForegroundColor Gray
+        Write-Host "    `"$executablePath`"" -ForegroundColor Gray
+    }
+
+    Write-Host ""
+}
+catch {
+    Write-Host ""
+    Write-Error "Build failed: $_" -ErrorAction Continue
+    Write-Host ""
+
+    if ($_.Exception.InnerException) {
+        Write-Verbose "Inner exception: $($_.Exception.InnerException.Message)"
+    }
+
+    exit 1
+}
+
+#endregion

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,606 @@
+#!/usr/bin/env bash
+
+# ============================================================================
+# MermaidPad Build Script
+# ============================================================================
+#
+# SYNOPSIS
+# Builds and publishes MermaidPad for the current platform.
+#
+# DESCRIPTION
+# This script builds and publishes MermaidPad for local development and
+# testing. It mirrors the CI/CD workflow in .github/workflows/build-and-release.yml
+# to ensure local builds produce artifacts identical to CI builds.
+#
+# The script:
+# 1. Detects the current OS and architecture
+# 2. Restores NuGet packages
+# 3. Publishes the application (which triggers asset hash generation)
+# 4. Optionally creates a zip artifact matching CI naming convention
+#
+# USAGE
+# ./build.sh [OPTIONS]
+#
+# OPTIONS
+# -v, --version VERSION              Version string to embed (default: "1.0.0-localdev")
+# -c, --configuration CONFIG         Build configuration: Debug or Release (default: Debug)
+# -x, --clean                        Remove previous build artifacts before building
+# -s, --skip-zip                     Skip creating the zip artifact (faster iteration)
+# -o, --output DIR                   Output directory (default: "./artifacts")
+# --verbose                          Enable verbose output
+# -h, --help                         Show this help message
+#
+# EXAMPLES
+# ./build.sh
+# Builds for the current platform with Debug configuration and version "1.0.0-localdev".
+#
+# ./build.sh -c Release
+# Builds for the current platform using Release configuration.
+#
+# ./build.sh -v 1.2.3 -c Release -x
+# Cleans previous artifacts and builds with version 1.2.3 using Release configuration.
+#
+# PREREQUISITES
+# - .NET 9.0 SDK or later
+# - Bash 4.0 or later
+# - zip utility (for creating artifacts)
+#
+# NOTES
+# Author: MermaidPad Contributors
+# Repository: https://github.com/udlose/MermaidPad
+#
+# This script is designed for local development and testing.
+# For releases, use the GitHub Actions workflow.
+# ============================================================================
+
+set -euo pipefail
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly PROJECT_FILE="$SCRIPT_DIR/MermaidPad.csproj"
+readonly SUPPORTED_RIDS=("win-x64" "win-arm64" "linux-x64" "osx-x64" "osx-arm64")
+
+# Default values
+VERSION="1.0.0-localdev"
+CONFIGURATION="Debug"
+CLEAN=false
+SKIP_ZIP=false
+OUTPUT_DIR="./artifacts"
+VERBOSE=false
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+# Colors for output (only if terminal supports them)
+if [[ -t 1 ]] && command -v tput &>/dev/null; then
+  readonly COLOR_RESET="$(tput sgr0)"
+  readonly COLOR_RED="$(tput setaf 1)"
+  readonly COLOR_GREEN="$(tput setaf 2)"
+  readonly COLOR_YELLOW="$(tput setaf 3)"
+  readonly COLOR_CYAN="$(tput setaf 6)"
+  readonly COLOR_MAGENTA="$(tput setaf 5)"
+  readonly COLOR_GRAY="$(tput setaf 8)"
+  readonly COLOR_WHITE="$(tput setaf 15)"
+else
+  readonly COLOR_RESET=""
+  readonly COLOR_RED=""
+  readonly COLOR_GREEN=""
+  readonly COLOR_YELLOW=""
+  readonly COLOR_CYAN=""
+  readonly COLOR_MAGENTA=""
+  readonly COLOR_GRAY=""
+  readonly COLOR_WHITE=""
+fi
+
+print_step() {
+  echo ""
+  echo "${COLOR_CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${COLOR_RESET}"
+  echo "${COLOR_CYAN}  $1${COLOR_RESET}"
+  echo "${COLOR_CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${COLOR_RESET}"
+}
+
+print_success() {
+  echo "${COLOR_GREEN}✓ $1${COLOR_RESET}"
+}
+
+print_info() {
+  echo "${COLOR_GRAY}  $1${COLOR_RESET}"
+}
+
+print_error() {
+  echo "${COLOR_RED}✗ $1${COLOR_RESET}" >&2
+}
+
+print_warning() {
+  echo "${COLOR_YELLOW}⚠ $1${COLOR_RESET}"
+}
+
+print_verbose() {
+  if [[ "$VERBOSE" == true ]]; then
+    echo "${COLOR_GRAY}[VERBOSE] $1${COLOR_RESET}"
+  fi
+}
+
+show_help() {
+  # Extract and display the header comment as help text
+  sed -n '/^# SYNOPSIS/,/^# =\+$/p' "$0" \
+    | grep -v '^# =\+$' \
+    | sed 's/^# //g' \
+    | sed 's/^#//g'
+  exit 0
+}
+
+# ============================================================================
+# Platform Detection
+# ============================================================================
+
+detect_os() {
+  local os=""
+  case "$(uname -s)" in
+    Linux*) os="linux" ;;
+    Darwin*) os="osx" ;;
+    MINGW*|MSYS*|CYGWIN*) os="win" ;;
+    *)
+      print_error "Unable to detect operating system: $(uname -s)"
+      print_error "Supported: Linux, macOS, Windows (via Git Bash/MSYS2)"
+      exit 1
+      ;;
+  esac
+  echo "$os"
+}
+
+detect_arch() {
+  local arch=""
+  case "$(uname -m)" in
+    x86_64|amd64) arch="x64" ;;
+    arm64|aarch64) arch="arm64" ;;
+    *)
+      print_error "Unsupported architecture: $(uname -m)"
+      print_error "Supported: x64, arm64"
+      exit 1
+      ;;
+  esac
+  echo "$arch"
+}
+
+get_runtime_identifier() {
+  local os=""
+  local arch=""
+  local rid=""
+
+  os="$(detect_os)"
+  arch="$(detect_arch)"
+  rid="${os}-${arch}"
+
+  # Validate against supported RIDs
+  local valid=false
+  local supported_rid=""
+  for supported_rid in "${SUPPORTED_RIDS[@]}"; do
+    if [[ "$rid" == "$supported_rid" ]]; then
+      valid=true
+      break
+    fi
+  done
+
+  if [[ "$valid" != true ]]; then
+    print_error "Unsupported Runtime Identifier: $rid"
+    print_error "Supported RIDs: ${SUPPORTED_RIDS[*]}"
+    exit 1
+  fi
+
+  echo "$rid"
+}
+
+get_executable_extension() {
+  local rid="$1"
+  if [[ "$rid" == win-* ]]; then
+    echo ".exe"
+  else
+    echo ""
+  fi
+}
+
+# ============================================================================
+# Prerequisite Validation
+# ============================================================================
+
+check_dotnet_sdk() {
+  print_verbose "Checking for .NET SDK..."
+
+  if ! command -v dotnet &>/dev/null; then
+    print_error ".NET SDK not found"
+    echo ""
+    echo "Please install the .NET 9.0 SDK from:"
+    echo "  https://dotnet.microsoft.com/download/dotnet/9.0"
+    exit 1
+  fi
+
+  local version=""
+  version="$(dotnet --version 2>&1)" || {
+    print_error "Failed to get .NET SDK version"
+    exit 1
+  }
+
+  print_verbose "Detected .NET SDK version: $version"
+
+  # Extract major version (handle formats like "9.0.100" or "9.0.100-preview.1")
+  local major_version=""
+  major_version="$(echo "$version" | cut -d'.' -f1)"
+
+  if [[ ! "$major_version" =~ ^[0-9]+$ ]]; then
+    print_error "Unable to parse .NET SDK version: $version"
+    echo ""
+    echo "Please ensure that the .NET 9.0 SDK is installed and that 'dotnet --version' returns a valid version string."
+    exit 1
+  fi
+
+  if [[ "$major_version" -lt 9 ]]; then
+    print_error ".NET 9.0 SDK or later is required. Found: $version"
+    exit 1
+  fi
+
+  print_success ".NET SDK $version detected"
+}
+
+check_zip_utility() {
+  if [[ "$SKIP_ZIP" == true ]]; then
+    return
+  fi
+
+  print_verbose "Checking for zip utility..."
+
+  if ! command -v zip &>/dev/null; then
+    print_error "zip utility not found"
+    echo ""
+    echo "Please install zip:"
+    echo "  Ubuntu/Debian: sudo apt-get install zip"
+    echo "  macOS: brew install zip (or use built-in)"
+    echo "  Or use --skip-zip to skip artifact creation"
+    exit 1
+  fi
+
+  print_verbose "zip utility found"
+}
+
+# ============================================================================
+# Git Metadata
+# ============================================================================
+
+get_git_commit_sha() {
+  local sha=""
+  if command -v git &>/dev/null && sha="$(git rev-parse HEAD 2>/dev/null)"; then
+    echo "$sha"
+  else
+    print_verbose "Git not available or not in a repository"
+    echo "local-build"
+  fi
+}
+
+# ============================================================================
+# Build Functions
+# ============================================================================
+
+clean_artifacts() {
+  print_step "Cleaning Previous Artifacts"
+
+  local publish_dir="$1"
+  local zip_path="${publish_dir}.zip"
+
+  if [[ -d "$publish_dir" ]]; then
+    rm -rf "$publish_dir"
+    print_success "Removed: $publish_dir"
+  fi
+
+  if [[ -f "$zip_path" ]]; then
+    rm -f "$zip_path"
+    print_success "Removed: $zip_path"
+  fi
+
+  # Remove zip artifacts created in the output directory using the
+  # MermaidPad-$VERSION-$CONFIGURATION-$rid.zip naming convention.
+  local rid
+  for rid in "${SUPPORTED_RIDS[@]}"; do
+    local rid_zip_path="$OUTPUT_DIR/MermaidPad-${VERSION}-${CONFIGURATION}-${rid}.zip"
+    if [[ -f "$rid_zip_path" ]]; then
+      rm -f "$rid_zip_path"
+      print_success "Removed: $rid_zip_path"
+    fi
+  done
+  # Clean bin/obj directories
+  if [[ -d "$SCRIPT_DIR/bin" ]]; then
+    rm -rf "$SCRIPT_DIR/bin"
+    print_success "Removed: bin/"
+  fi
+
+  if [[ -d "$SCRIPT_DIR/obj" ]]; then
+    rm -rf "$SCRIPT_DIR/obj"
+    print_success "Removed: obj/"
+  fi
+}
+
+restore_dependencies() {
+  print_step "Restoring Dependencies"
+  print_verbose "Running: dotnet restore $PROJECT_FILE"
+
+  if ! dotnet "restore" "$PROJECT_FILE"; then
+    print_error "dotnet restore failed"
+    exit 1
+  fi
+
+  print_success "Dependencies restored"
+}
+
+publish_application() {
+  local rid="$1"
+  local publish_dir="$2"
+  local version="$3"
+  local build_date="$4"
+  local commit_sha="$5"
+
+  print_step "Publishing Application"
+
+  # Ensure output directory exists
+  mkdir -p "$(dirname "$publish_dir")"
+
+  local publish_args=(
+    "publish"
+    "$PROJECT_FILE"
+    "-c" "$CONFIGURATION"
+    "-r" "$rid"
+    "-o" "$publish_dir"
+    "-p:Version=$version"
+    "-p:MermaidPadBuildDate=$build_date"
+    "-p:MermaidPadCommitSha=$commit_sha"
+  )
+
+  print_verbose "Running: dotnet ${publish_args[*]}"
+
+  if ! dotnet "${publish_args[@]}"; then
+    print_error "dotnet publish failed"
+    exit 1
+  fi
+
+  print_success "Application published to: $publish_dir"
+}
+
+create_zip_artifact() {
+  local publish_dir="$1"
+  local zip_path="$2"
+
+  print_step "Creating Zip Artifact"
+
+  # Remove existing zip if present
+  if [[ -f "$zip_path" ]]; then
+    rm -f "$zip_path"
+  fi
+
+  print_verbose "Creating zip: $zip_path"
+
+  # Create zip from publish directory contents (excluding .DS_Store)
+  # Using subshell to change directory without affecting the main script
+  (cd "$publish_dir" && zip -r "$zip_path" . -x "*.DS_Store*")
+
+  print_success "Zip artifact created: $zip_path"
+}
+
+# ============================================================================
+# Argument Parsing
+# ============================================================================
+
+parse_arguments() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -v|--version)
+        if [[ -z "${2:-}" ]]; then
+          print_error "Version argument requires a value"
+          exit 1
+        fi
+        VERSION="$2"
+        shift 2
+        ;;
+      -c|--configuration)
+        if [[ -z "${2:-}" ]]; then
+          print_error "Configuration argument requires a value (Debug or Release)"
+          exit 1
+        fi
+        CONFIGURATION="$2"
+        shift 2
+        ;;
+      -x|--clean)
+        CLEAN=true
+        shift
+        ;;
+      -s|--skip-zip)
+        SKIP_ZIP=true
+        shift
+        ;;
+      -o|--output)
+        if [[ -z "${2:-}" ]]; then
+          print_error "Output argument requires a value"
+          exit 1
+        fi
+        OUTPUT_DIR="$2"
+        shift 2
+        ;;
+      --verbose)
+        VERBOSE=true
+        shift
+        ;;
+      -h|--help)
+        show_help
+        ;;
+      *)
+        print_error "Unknown option: $1"
+        echo "Use --help for usage information"
+        exit 1
+        ;;
+    esac
+  done
+
+  if [[ "$CONFIGURATION" != "Debug" && "$CONFIGURATION" != "Release" ]]; then
+    print_error "Invalid configuration: $CONFIGURATION (must be Debug or Release)"
+    exit 1
+  fi
+}
+
+# ============================================================================
+# Main Script
+# ============================================================================
+
+main() {
+  parse_arguments "$@"
+
+  echo ""
+  echo "${COLOR_MAGENTA}╔══════════════════════════════════════════════════════════════╗${COLOR_RESET}"
+  echo "${COLOR_MAGENTA}║               MermaidPad Build Script                        ║${COLOR_RESET}"
+  echo "${COLOR_MAGENTA}╚══════════════════════════════════════════════════════════════╝${COLOR_RESET}"
+
+  # Validate project file exists
+  if [[ ! -f "$PROJECT_FILE" ]]; then
+    print_error "Project file not found: $PROJECT_FILE"
+    print_error "Ensure this script is in the repository root."
+    exit 1
+  fi
+
+  # Resolve output directory to absolute path
+  if [[ "$OUTPUT_DIR" != /* ]]; then
+    OUTPUT_DIR="$SCRIPT_DIR/$OUTPUT_DIR"
+  fi
+
+  # Ensure output directory exists
+  mkdir -p "$OUTPUT_DIR"
+  # Step 1: Validate prerequisites
+  print_step "Validating Prerequisites"
+  check_dotnet_sdk
+  check_zip_utility
+
+  # Step 2: Detect platform
+  print_step "Detecting Platform"
+  local rid=""
+  local extension=""
+  rid="$(get_runtime_identifier)"
+  extension="$(get_executable_extension "$rid")"
+  print_success "Runtime Identifier: $rid"
+
+  # Step 3: Gather build metadata
+  print_step "Gathering Build Metadata"
+  local build_date=""
+  local commit_sha=""
+  build_date="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  commit_sha="$(get_git_commit_sha)"
+  print_info "Version:        $VERSION"
+  print_info "Configuration:  $CONFIGURATION"
+  print_info "Build Date:     $build_date"
+  print_info "Commit SHA:     $commit_sha"
+
+  # Validate VERSION for path safety
+  if [[ "$VERSION" =~ [\/\\:] || "$VERSION" == *".."* ]]; then
+    print_error "Invalid characters in version string: $VERSION"
+    print_error "Version must not contain '/', '\\', '..', or ':'"
+    exit 1
+  fi
+
+  # Helper to resolve absolute, canonical paths in a portable way
+  resolve_path() {
+    local path="$1"
+
+    if command -v realpath >/dev/null 2>&1; then
+      realpath "$path"
+      return
+    fi
+
+    if command -v python3 >/dev/null 2>&1; then
+      python3 - "$path" <<'PY'
+import os
+import sys
+
+if len(sys.argv) != 2:
+    sys.exit(1)
+
+print(os.path.realpath(sys.argv[1]))
+PY
+      return
+    fi
+
+    # Fallback: best-effort absolute path resolution without canonicalization
+    if [ -d "$path" ]; then
+      ( cd "$path" 2>/dev/null && pwd -P ) || printf '%s\n' "$path"
+    else
+      case "$path" in
+        /*) printf '%s\n' "$path" ;;
+        *) printf '%s/%s\n' "$(pwd -P)" "$path" ;;
+      esac
+    fi
+  }
+
+  # Ensure OUTPUT_DIR exists and normalize it
+  mkdir -p "$OUTPUT_DIR"
+  OUTPUT_DIR="$(resolve_path "$OUTPUT_DIR")"
+  local publish_dir zip_name zip_path
+  OUTPUT_DIR_WITH_SLASH="$OUTPUT_DIR/"
+  publish_dir="$OUTPUT_DIR/MermaidPad-$VERSION-$CONFIGURATION-$rid"
+  zip_name="MermaidPad-$VERSION-$CONFIGURATION-$rid.zip"
+  zip_path="$OUTPUT_DIR/$zip_name"
+
+  # Ensure publish_dir and zip_path are under OUTPUT_DIR (enforce path-separator boundary)
+  publish_dir_resolved="$(resolve_path "$publish_dir")"
+  zip_path_resolved="$(resolve_path "$zip_path")"
+  if [[ "$publish_dir_resolved" != "$OUTPUT_DIR_WITH_SLASH"* ]] || [[ "$zip_path_resolved" != "$OUTPUT_DIR_WITH_SLASH"* ]]; then
+    print_error "Resolved artifact paths escape the intended output directory."
+    exit 1
+  fi
+
+  # Step 4: Clean if requested
+  if [[ "$CLEAN" == true ]]; then
+    clean_artifacts "$publish_dir"
+  fi
+
+  # Step 5: Restore dependencies
+  restore_dependencies
+
+  # Step 6: Publish
+  publish_application "$rid" "$publish_dir" "$VERSION" "$build_date" "$commit_sha"
+
+  # Step 7: Set executable permission (non-Windows)
+  local executable_name=""
+  local executable_path=""
+  executable_name="MermaidPad${extension}"
+  executable_path="$publish_dir/$executable_name"
+
+  if [[ "$rid" != win-* ]] && [[ -f "$executable_path" ]]; then
+    chmod +x "$executable_path"
+    print_verbose "Set executable permission on: $executable_path"
+  fi
+
+  # Step 8: Create zip artifact (unless skipped)
+  if [[ "$SKIP_ZIP" != true ]]; then
+    create_zip_artifact "$publish_dir" "$zip_path"
+  else
+    print_info "Skipping zip creation (--skip-zip specified)"
+  fi
+
+  # Summary
+  echo ""
+  echo "${COLOR_GREEN}╔══════════════════════════════════════════════════════════════╗${COLOR_RESET}"
+  echo "${COLOR_GREEN}║                    Build Complete!                           ║${COLOR_RESET}"
+  echo "${COLOR_GREEN}╚══════════════════════════════════════════════════════════════╝${COLOR_RESET}"
+  echo ""
+  echo "${COLOR_WHITE}  Artifacts:${COLOR_RESET}"
+  echo "${COLOR_GRAY}    Publish Directory: $publish_dir${COLOR_RESET}"
+
+  if [[ "$SKIP_ZIP" != true ]]; then
+    echo "${COLOR_GRAY}    Zip Artifact:      $zip_path${COLOR_RESET}"
+  fi
+
+  echo ""
+  echo "${COLOR_WHITE}  To run the application:${COLOR_RESET}"
+  echo "${COLOR_GRAY}    $executable_path${COLOR_RESET}"
+  echo ""
+}
+
+# Run main function with all arguments
+main "$@"


### PR DESCRIPTION
#### PR Classification
Adds robust local build tooling and improves documentation for reproducible, cross-platform publishing.

Resolves #347 

#### PR Summary
Introduces cross-platform build scripts to align local builds with CI outputs and updates documentation for clarity and accuracy.
- fix compile errors in RELEASE
- fix broken images on README
- Added build.ps1 (PowerShell) and build.sh (Bash) scripts for local, reproducible, platform-aware publishing with artifact naming matching CI.
- Updated README.md to document new build scripts, clarify artifact testing, and improve instructions and formatting.
- Improved conditional compilation in App.axaml.cs to ensure developer tools are only included in debug builds.
- Fixed Directory.Build.props to correctly handle DefineConstants for RuntimeIdentifier.
- Enhanced README.md with clearer language, updated badge URLs, and consistent artifact terminology.
